### PR TITLE
#48/stronger typing for entity builder

### DIFF
--- a/src/Eftdb/Configuration/ContinuousAggregate/ContinuousAggregateTypeBuilder.cs
+++ b/src/Eftdb/Configuration/ContinuousAggregate/ContinuousAggregateTypeBuilder.cs
@@ -30,6 +30,77 @@ namespace CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.ContinuousAggre
             string? chunkInterval = null)
             where TEntity : class
             where TSourceEntity : class
+            => IsContinuousAggregateCore<TEntity, TSourceEntity>(entityTypeBuilder, materializedViewName, timeBucketWidth, Box(propertyExpression), timeBucketGroupBy, chunkInterval);
+
+        /// <inheritdoc cref="IsContinuousAggregate{TEntity, TSourceEntity}(EntityTypeBuilder{TEntity}, string, string, Expression{Func{TSourceEntity, DateTime}}, bool, string)"/>
+        public static ContinuousAggregateBuilder<TEntity, TSourceEntity> IsContinuousAggregate<TEntity, TSourceEntity>(
+            this EntityTypeBuilder<TEntity> entityTypeBuilder,
+            string materializedViewName,
+            string timeBucketWidth,
+            Expression<Func<TSourceEntity, DateTimeOffset>> propertyExpression,
+            bool timeBucketGroupBy = true,
+            string? chunkInterval = null)
+            where TEntity : class
+            where TSourceEntity : class
+            => IsContinuousAggregateCore<TEntity, TSourceEntity>(entityTypeBuilder, materializedViewName, timeBucketWidth, Box(propertyExpression), timeBucketGroupBy, chunkInterval);
+
+        /// <inheritdoc cref="IsContinuousAggregate{TEntity, TSourceEntity}(EntityTypeBuilder{TEntity}, string, string, Expression{Func{TSourceEntity, DateTime}}, bool, string)"/>
+        public static ContinuousAggregateBuilder<TEntity, TSourceEntity> IsContinuousAggregate<TEntity, TSourceEntity>(
+            this EntityTypeBuilder<TEntity> entityTypeBuilder,
+            string materializedViewName,
+            string timeBucketWidth,
+            Expression<Func<TSourceEntity, DateOnly>> propertyExpression,
+            bool timeBucketGroupBy = true,
+            string? chunkInterval = null)
+            where TEntity : class
+            where TSourceEntity : class
+            => IsContinuousAggregateCore<TEntity, TSourceEntity>(entityTypeBuilder, materializedViewName, timeBucketWidth, Box(propertyExpression), timeBucketGroupBy, chunkInterval);
+
+        /// <inheritdoc cref="IsContinuousAggregate{TEntity, TSourceEntity}(EntityTypeBuilder{TEntity}, string, string, Expression{Func{TSourceEntity, DateTime}}, bool, string)"/>
+        public static ContinuousAggregateBuilder<TEntity, TSourceEntity> IsContinuousAggregate<TEntity, TSourceEntity>(
+            this EntityTypeBuilder<TEntity> entityTypeBuilder,
+            string materializedViewName,
+            string timeBucketWidth,
+            Expression<Func<TSourceEntity, long>> propertyExpression,
+            bool timeBucketGroupBy = true,
+            string? chunkInterval = null)
+            where TEntity : class
+            where TSourceEntity : class
+            => IsContinuousAggregateCore<TEntity, TSourceEntity>(entityTypeBuilder, materializedViewName, timeBucketWidth, Box(propertyExpression), timeBucketGroupBy, chunkInterval);
+
+        /// <inheritdoc cref="IsContinuousAggregate{TEntity, TSourceEntity}(EntityTypeBuilder{TEntity}, string, string, Expression{Func{TSourceEntity, DateTime}}, bool, string)"/>
+        public static ContinuousAggregateBuilder<TEntity, TSourceEntity> IsContinuousAggregate<TEntity, TSourceEntity>(
+            this EntityTypeBuilder<TEntity> entityTypeBuilder,
+            string materializedViewName,
+            string timeBucketWidth,
+            Expression<Func<TSourceEntity, int>> propertyExpression,
+            bool timeBucketGroupBy = true,
+            string? chunkInterval = null)
+            where TEntity : class
+            where TSourceEntity : class
+            => IsContinuousAggregateCore<TEntity, TSourceEntity>(entityTypeBuilder, materializedViewName, timeBucketWidth, Box(propertyExpression), timeBucketGroupBy, chunkInterval);
+
+        /// <inheritdoc cref="IsContinuousAggregate{TEntity, TSourceEntity}(EntityTypeBuilder{TEntity}, string, string, Expression{Func{TSourceEntity, DateTime}}, bool, string)"/>
+        public static ContinuousAggregateBuilder<TEntity, TSourceEntity> IsContinuousAggregate<TEntity, TSourceEntity>(
+            this EntityTypeBuilder<TEntity> entityTypeBuilder,
+            string materializedViewName,
+            string timeBucketWidth,
+            Expression<Func<TSourceEntity, short>> propertyExpression,
+            bool timeBucketGroupBy = true,
+            string? chunkInterval = null)
+            where TEntity : class
+            where TSourceEntity : class
+            => IsContinuousAggregateCore<TEntity, TSourceEntity>(entityTypeBuilder, materializedViewName, timeBucketWidth, Box(propertyExpression), timeBucketGroupBy, chunkInterval);
+
+        private static ContinuousAggregateBuilder<TEntity, TSourceEntity> IsContinuousAggregateCore<TEntity, TSourceEntity>(
+            EntityTypeBuilder<TEntity> entityTypeBuilder,
+            string materializedViewName,
+            string timeBucketWidth,
+            Expression<Func<TSourceEntity, object>> propertyExpression,
+            bool timeBucketGroupBy,
+            string? chunkInterval)
+            where TEntity : class
+            where TSourceEntity : class
         {
             // Configure the entity to map to a view instead of a table
             // This prevents EF Core from trying to create a table for the continuous aggregate
@@ -52,5 +123,14 @@ namespace CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.ContinuousAggre
 
             return new ContinuousAggregateBuilder<TEntity, TSourceEntity>(entityTypeBuilder);
         }
+
+        // Lifts a typed time-column expression to Expression<Func<TSourceEntity, object>> by inserting
+        // a Convert node, so the shared core method can extract the property name uniformly.
+        private static Expression<Func<TSourceEntity, object>> Box<TSourceEntity, TProperty>(
+            Expression<Func<TSourceEntity, TProperty>> expression)
+            where TProperty : struct
+            => Expression.Lambda<Func<TSourceEntity, object>>(
+                Expression.Convert(expression.Body, typeof(object)),
+                expression.Parameters);
     }
 }

--- a/src/Eftdb/Configuration/Hypertable/HypertableTypeBuilder.cs
+++ b/src/Eftdb/Configuration/Hypertable/HypertableTypeBuilder.cs
@@ -16,13 +16,48 @@ namespace CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.Hypertable
         /// </summary>
         /// <remarks>
         /// This is the essential first step to enable TimescaleDB features for an entity.
-        /// It corresponds to the `create_hypertable` function in PostgreSQL.
+        /// It corresponds to the <c>create_hypertable</c> function in PostgreSQL.
         /// </remarks>
         /// <typeparam name="TEntity">The entity type being configured.</typeparam>
         /// <param name="entityTypeBuilder">The builder for the entity type.</param>
-        /// <param name="timePropertyExpression">A lambda expression representing the time column (e.g., `x => x.Timestamp`).</param>
+        /// <param name="timePropertyExpression">A lambda expression representing the time column (e.g., <c>x =&gt; x.Timestamp</c>).</param>
         public static EntityTypeBuilder<TEntity> IsHypertable<TEntity>(
             this EntityTypeBuilder<TEntity> entityTypeBuilder,
+            Expression<Func<TEntity, DateTime>> timePropertyExpression) where TEntity : class
+            => IsHypertableCore(entityTypeBuilder, Box(timePropertyExpression));
+
+        /// <inheritdoc cref="IsHypertable{TEntity}(EntityTypeBuilder{TEntity}, Expression{Func{TEntity, DateTime}})"/>
+        public static EntityTypeBuilder<TEntity> IsHypertable<TEntity>(
+            this EntityTypeBuilder<TEntity> entityTypeBuilder,
+            Expression<Func<TEntity, DateTimeOffset>> timePropertyExpression) where TEntity : class
+            => IsHypertableCore(entityTypeBuilder, Box(timePropertyExpression));
+
+        /// <inheritdoc cref="IsHypertable{TEntity}(EntityTypeBuilder{TEntity}, Expression{Func{TEntity, DateTime}})"/>
+        public static EntityTypeBuilder<TEntity> IsHypertable<TEntity>(
+            this EntityTypeBuilder<TEntity> entityTypeBuilder,
+            Expression<Func<TEntity, DateOnly>> timePropertyExpression) where TEntity : class
+            => IsHypertableCore(entityTypeBuilder, Box(timePropertyExpression));
+
+        /// <inheritdoc cref="IsHypertable{TEntity}(EntityTypeBuilder{TEntity}, Expression{Func{TEntity, DateTime}})"/>
+        public static EntityTypeBuilder<TEntity> IsHypertable<TEntity>(
+            this EntityTypeBuilder<TEntity> entityTypeBuilder,
+            Expression<Func<TEntity, long>> timePropertyExpression) where TEntity : class
+            => IsHypertableCore(entityTypeBuilder, Box(timePropertyExpression));
+
+        /// <inheritdoc cref="IsHypertable{TEntity}(EntityTypeBuilder{TEntity}, Expression{Func{TEntity, DateTime}})"/>
+        public static EntityTypeBuilder<TEntity> IsHypertable<TEntity>(
+            this EntityTypeBuilder<TEntity> entityTypeBuilder,
+            Expression<Func<TEntity, int>> timePropertyExpression) where TEntity : class
+            => IsHypertableCore(entityTypeBuilder, Box(timePropertyExpression));
+
+        /// <inheritdoc cref="IsHypertable{TEntity}(EntityTypeBuilder{TEntity}, Expression{Func{TEntity, DateTime}})"/>
+        public static EntityTypeBuilder<TEntity> IsHypertable<TEntity>(
+            this EntityTypeBuilder<TEntity> entityTypeBuilder,
+            Expression<Func<TEntity, short>> timePropertyExpression) where TEntity : class
+            => IsHypertableCore(entityTypeBuilder, Box(timePropertyExpression));
+
+        private static EntityTypeBuilder<TEntity> IsHypertableCore<TEntity>(
+            EntityTypeBuilder<TEntity> entityTypeBuilder,
             Expression<Func<TEntity, object>> timePropertyExpression) where TEntity : class
         {
             string propertyName = GetPropertyName(timePropertyExpression);
@@ -32,6 +67,15 @@ namespace CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.Hypertable
 
             return entityTypeBuilder;
         }
+
+        // Lifts a typed time-column expression to Expression<Func<TEntity, object>> by inserting a Convert
+        // node, so the shared core method can extract the property name uniformly via GetPropertyName.
+        private static Expression<Func<TEntity, object>> Box<TEntity, TProperty>(
+            Expression<Func<TEntity, TProperty>> expression)
+            where TProperty : struct
+            => Expression.Lambda<Func<TEntity, object>>(
+                Expression.Convert(expression.Body, typeof(object)),
+                expression.Parameters);
 
         /// <summary>
         /// Adds an additional partitioning dimension to the hypertable.

--- a/tests/Eftdb.Tests/TypeBuilders/ContinuousAggregateBuilderTests.cs
+++ b/tests/Eftdb.Tests/TypeBuilders/ContinuousAggregateBuilderTests.cs
@@ -1580,4 +1580,289 @@ public class ContinuousAggregateBuilderTests
     }
 
     #endregion
+
+    #region IsContinuousAggregate_Should_Accept_DateTimeOffset_TimeColumn
+
+    private class IsContinuousAggregate_Should_Accept_DateTimeOffset_TimeColumn_MetricEntity
+    {
+        public DateTimeOffset Timestamp { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class IsContinuousAggregate_Should_Accept_DateTimeOffset_TimeColumn_HourlyMetricAggregate
+    {
+        public DateTimeOffset TimeBucket { get; set; }
+        public double AvgValue { get; set; }
+    }
+
+    private class IsContinuousAggregate_Should_Accept_DateTimeOffset_TimeColumn_Context : DbContext
+    {
+        public DbSet<IsContinuousAggregate_Should_Accept_DateTimeOffset_TimeColumn_MetricEntity> Metrics => Set<IsContinuousAggregate_Should_Accept_DateTimeOffset_TimeColumn_MetricEntity>();
+        public DbSet<IsContinuousAggregate_Should_Accept_DateTimeOffset_TimeColumn_HourlyMetricAggregate> HourlyMetrics => Set<IsContinuousAggregate_Should_Accept_DateTimeOffset_TimeColumn_HourlyMetricAggregate>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test")
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<IsContinuousAggregate_Should_Accept_DateTimeOffset_TimeColumn_MetricEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("dto_metrics");
+                entity.IsHypertable(x => x.Timestamp);
+            });
+
+            modelBuilder.Entity<IsContinuousAggregate_Should_Accept_DateTimeOffset_TimeColumn_HourlyMetricAggregate>(entity =>
+            {
+                entity.HasNoKey();
+                entity.IsContinuousAggregate<IsContinuousAggregate_Should_Accept_DateTimeOffset_TimeColumn_HourlyMetricAggregate, IsContinuousAggregate_Should_Accept_DateTimeOffset_TimeColumn_MetricEntity>(
+                    "dto_hourly_metrics",
+                    "1 hour",
+                    x => x.Timestamp)
+                .AddAggregateFunction(x => x.AvgValue, x => x.Value, EAggregateFunction.Avg);
+            });
+        }
+    }
+
+    [Fact]
+    public void IsContinuousAggregate_Should_Accept_DateTimeOffset_TimeColumn()
+    {
+        using IsContinuousAggregate_Should_Accept_DateTimeOffset_TimeColumn_Context context = new();
+        IModel model = GetModel(context);
+        IEntityType entityType = model.FindEntityType(typeof(IsContinuousAggregate_Should_Accept_DateTimeOffset_TimeColumn_HourlyMetricAggregate))!;
+
+        Assert.Equal("dto_hourly_metrics", entityType.FindAnnotation(ContinuousAggregateAnnotations.MaterializedViewName)?.Value);
+        Assert.Equal("Timestamp", entityType.FindAnnotation(ContinuousAggregateAnnotations.TimeBucketSourceColumn)?.Value);
+    }
+
+    #endregion
+
+    #region IsContinuousAggregate_Should_Accept_DateOnly_TimeColumn
+
+    private class IsContinuousAggregate_Should_Accept_DateOnly_TimeColumn_MetricEntity
+    {
+        public DateOnly Day { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class IsContinuousAggregate_Should_Accept_DateOnly_TimeColumn_DailyMetricAggregate
+    {
+        public DateOnly TimeBucket { get; set; }
+        public double AvgValue { get; set; }
+    }
+
+    private class IsContinuousAggregate_Should_Accept_DateOnly_TimeColumn_Context : DbContext
+    {
+        public DbSet<IsContinuousAggregate_Should_Accept_DateOnly_TimeColumn_MetricEntity> Metrics => Set<IsContinuousAggregate_Should_Accept_DateOnly_TimeColumn_MetricEntity>();
+        public DbSet<IsContinuousAggregate_Should_Accept_DateOnly_TimeColumn_DailyMetricAggregate> DailyMetrics => Set<IsContinuousAggregate_Should_Accept_DateOnly_TimeColumn_DailyMetricAggregate>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test")
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<IsContinuousAggregate_Should_Accept_DateOnly_TimeColumn_MetricEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("dateonly_metrics");
+                entity.IsHypertable(x => x.Day);
+            });
+
+            modelBuilder.Entity<IsContinuousAggregate_Should_Accept_DateOnly_TimeColumn_DailyMetricAggregate>(entity =>
+            {
+                entity.HasNoKey();
+                entity.IsContinuousAggregate<IsContinuousAggregate_Should_Accept_DateOnly_TimeColumn_DailyMetricAggregate, IsContinuousAggregate_Should_Accept_DateOnly_TimeColumn_MetricEntity>(
+                    "dateonly_daily_metrics",
+                    "1 day",
+                    x => x.Day)
+                .AddAggregateFunction(x => x.AvgValue, x => x.Value, EAggregateFunction.Avg);
+            });
+        }
+    }
+
+    [Fact]
+    public void IsContinuousAggregate_Should_Accept_DateOnly_TimeColumn()
+    {
+        using IsContinuousAggregate_Should_Accept_DateOnly_TimeColumn_Context context = new();
+        IModel model = GetModel(context);
+        IEntityType entityType = model.FindEntityType(typeof(IsContinuousAggregate_Should_Accept_DateOnly_TimeColumn_DailyMetricAggregate))!;
+
+        Assert.Equal("dateonly_daily_metrics", entityType.FindAnnotation(ContinuousAggregateAnnotations.MaterializedViewName)?.Value);
+        Assert.Equal("Day", entityType.FindAnnotation(ContinuousAggregateAnnotations.TimeBucketSourceColumn)?.Value);
+    }
+
+    #endregion
+
+    #region IsContinuousAggregate_Should_Accept_Long_TimeColumn
+
+    private class IsContinuousAggregate_Should_Accept_Long_TimeColumn_MetricEntity
+    {
+        public long EpochMicros { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class IsContinuousAggregate_Should_Accept_Long_TimeColumn_BucketedMetricAggregate
+    {
+        public long TimeBucket { get; set; }
+        public double AvgValue { get; set; }
+    }
+
+    private class IsContinuousAggregate_Should_Accept_Long_TimeColumn_Context : DbContext
+    {
+        public DbSet<IsContinuousAggregate_Should_Accept_Long_TimeColumn_MetricEntity> Metrics => Set<IsContinuousAggregate_Should_Accept_Long_TimeColumn_MetricEntity>();
+        public DbSet<IsContinuousAggregate_Should_Accept_Long_TimeColumn_BucketedMetricAggregate> Buckets => Set<IsContinuousAggregate_Should_Accept_Long_TimeColumn_BucketedMetricAggregate>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test")
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<IsContinuousAggregate_Should_Accept_Long_TimeColumn_MetricEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("long_metrics");
+                entity.IsHypertable(x => x.EpochMicros);
+            });
+
+            modelBuilder.Entity<IsContinuousAggregate_Should_Accept_Long_TimeColumn_BucketedMetricAggregate>(entity =>
+            {
+                entity.HasNoKey();
+                entity.IsContinuousAggregate<IsContinuousAggregate_Should_Accept_Long_TimeColumn_BucketedMetricAggregate, IsContinuousAggregate_Should_Accept_Long_TimeColumn_MetricEntity>(
+                    "long_bucketed_metrics",
+                    "3600000000",
+                    x => x.EpochMicros)
+                .AddAggregateFunction(x => x.AvgValue, x => x.Value, EAggregateFunction.Avg);
+            });
+        }
+    }
+
+    [Fact]
+    public void IsContinuousAggregate_Should_Accept_Long_TimeColumn()
+    {
+        using IsContinuousAggregate_Should_Accept_Long_TimeColumn_Context context = new();
+        IModel model = GetModel(context);
+        IEntityType entityType = model.FindEntityType(typeof(IsContinuousAggregate_Should_Accept_Long_TimeColumn_BucketedMetricAggregate))!;
+
+        Assert.Equal("long_bucketed_metrics", entityType.FindAnnotation(ContinuousAggregateAnnotations.MaterializedViewName)?.Value);
+        Assert.Equal("EpochMicros", entityType.FindAnnotation(ContinuousAggregateAnnotations.TimeBucketSourceColumn)?.Value);
+    }
+
+    #endregion
+
+    #region IsContinuousAggregate_Should_Accept_Int_TimeColumn
+
+    private class IsContinuousAggregate_Should_Accept_Int_TimeColumn_MetricEntity
+    {
+        public int Ticks { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class IsContinuousAggregate_Should_Accept_Int_TimeColumn_BucketedMetricAggregate
+    {
+        public int TimeBucket { get; set; }
+        public double AvgValue { get; set; }
+    }
+
+    private class IsContinuousAggregate_Should_Accept_Int_TimeColumn_Context : DbContext
+    {
+        public DbSet<IsContinuousAggregate_Should_Accept_Int_TimeColumn_MetricEntity> Metrics => Set<IsContinuousAggregate_Should_Accept_Int_TimeColumn_MetricEntity>();
+        public DbSet<IsContinuousAggregate_Should_Accept_Int_TimeColumn_BucketedMetricAggregate> Buckets => Set<IsContinuousAggregate_Should_Accept_Int_TimeColumn_BucketedMetricAggregate>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test")
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<IsContinuousAggregate_Should_Accept_Int_TimeColumn_MetricEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("int_metrics");
+                entity.IsHypertable(x => x.Ticks);
+            });
+
+            modelBuilder.Entity<IsContinuousAggregate_Should_Accept_Int_TimeColumn_BucketedMetricAggregate>(entity =>
+            {
+                entity.HasNoKey();
+                entity.IsContinuousAggregate<IsContinuousAggregate_Should_Accept_Int_TimeColumn_BucketedMetricAggregate, IsContinuousAggregate_Should_Accept_Int_TimeColumn_MetricEntity>(
+                    "int_bucketed_metrics",
+                    "3600",
+                    x => x.Ticks)
+                .AddAggregateFunction(x => x.AvgValue, x => x.Value, EAggregateFunction.Avg);
+            });
+        }
+    }
+
+    [Fact]
+    public void IsContinuousAggregate_Should_Accept_Int_TimeColumn()
+    {
+        using IsContinuousAggregate_Should_Accept_Int_TimeColumn_Context context = new();
+        IModel model = GetModel(context);
+        IEntityType entityType = model.FindEntityType(typeof(IsContinuousAggregate_Should_Accept_Int_TimeColumn_BucketedMetricAggregate))!;
+
+        Assert.Equal("int_bucketed_metrics", entityType.FindAnnotation(ContinuousAggregateAnnotations.MaterializedViewName)?.Value);
+        Assert.Equal("Ticks", entityType.FindAnnotation(ContinuousAggregateAnnotations.TimeBucketSourceColumn)?.Value);
+    }
+
+    #endregion
+
+    #region IsContinuousAggregate_Should_Accept_Short_TimeColumn
+
+    private class IsContinuousAggregate_Should_Accept_Short_TimeColumn_MetricEntity
+    {
+        public short SlotIndex { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class IsContinuousAggregate_Should_Accept_Short_TimeColumn_BucketedMetricAggregate
+    {
+        public short TimeBucket { get; set; }
+        public double AvgValue { get; set; }
+    }
+
+    private class IsContinuousAggregate_Should_Accept_Short_TimeColumn_Context : DbContext
+    {
+        public DbSet<IsContinuousAggregate_Should_Accept_Short_TimeColumn_MetricEntity> Metrics => Set<IsContinuousAggregate_Should_Accept_Short_TimeColumn_MetricEntity>();
+        public DbSet<IsContinuousAggregate_Should_Accept_Short_TimeColumn_BucketedMetricAggregate> Buckets => Set<IsContinuousAggregate_Should_Accept_Short_TimeColumn_BucketedMetricAggregate>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test")
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<IsContinuousAggregate_Should_Accept_Short_TimeColumn_MetricEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("short_metrics");
+                entity.IsHypertable(x => x.SlotIndex);
+            });
+
+            modelBuilder.Entity<IsContinuousAggregate_Should_Accept_Short_TimeColumn_BucketedMetricAggregate>(entity =>
+            {
+                entity.HasNoKey();
+                entity.IsContinuousAggregate<IsContinuousAggregate_Should_Accept_Short_TimeColumn_BucketedMetricAggregate, IsContinuousAggregate_Should_Accept_Short_TimeColumn_MetricEntity>(
+                    "short_bucketed_metrics",
+                    "10",
+                    x => x.SlotIndex)
+                .AddAggregateFunction(x => x.AvgValue, x => x.Value, EAggregateFunction.Avg);
+            });
+        }
+    }
+
+    [Fact]
+    public void IsContinuousAggregate_Should_Accept_Short_TimeColumn()
+    {
+        using IsContinuousAggregate_Should_Accept_Short_TimeColumn_Context context = new();
+        IModel model = GetModel(context);
+        IEntityType entityType = model.FindEntityType(typeof(IsContinuousAggregate_Should_Accept_Short_TimeColumn_BucketedMetricAggregate))!;
+
+        Assert.Equal("short_bucketed_metrics", entityType.FindAnnotation(ContinuousAggregateAnnotations.MaterializedViewName)?.Value);
+        Assert.Equal("SlotIndex", entityType.FindAnnotation(ContinuousAggregateAnnotations.TimeBucketSourceColumn)?.Value);
+    }
+
+    #endregion
 }

--- a/tests/Eftdb.Tests/TypeBuilders/HypertableTypeBuilderTests.cs
+++ b/tests/Eftdb.Tests/TypeBuilders/HypertableTypeBuilderTests.cs
@@ -1012,4 +1012,204 @@ public class HypertableTypeBuilderTests
     }
 
     #endregion
+
+    #region IsHypertable_Should_Accept_DateTimeOffset_TimeColumn
+
+    private class DateTimeOffsetTimeColumnEntity
+    {
+        public DateTimeOffset EventTime { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class DateTimeOffsetTimeColumnContext : DbContext
+    {
+        public DbSet<DateTimeOffsetTimeColumnEntity> Metrics => Set<DateTimeOffsetTimeColumnEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test")
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<DateTimeOffsetTimeColumnEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("metrics_datetimeoffset_time");
+                entity.IsHypertable(x => x.EventTime);
+            });
+        }
+    }
+
+    [Fact]
+    public void IsHypertable_Should_Accept_DateTimeOffset_TimeColumn()
+    {
+        using DateTimeOffsetTimeColumnContext context = new();
+        IModel model = GetModel(context);
+        IEntityType entityType = model.FindEntityType(typeof(DateTimeOffsetTimeColumnEntity))!;
+
+        Assert.Equal("EventTime", entityType.FindAnnotation(HypertableAnnotations.HypertableTimeColumn)?.Value);
+        Assert.Equal(true, entityType.FindAnnotation(HypertableAnnotations.IsHypertable)?.Value);
+    }
+
+    #endregion
+
+    #region IsHypertable_Should_Accept_DateOnly_TimeColumn
+
+    private class DateOnlyTimeColumnEntity
+    {
+        public DateOnly EventDate { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class DateOnlyTimeColumnContext : DbContext
+    {
+        public DbSet<DateOnlyTimeColumnEntity> Metrics => Set<DateOnlyTimeColumnEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test")
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<DateOnlyTimeColumnEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("metrics_dateonly_time");
+                entity.IsHypertable(x => x.EventDate);
+            });
+        }
+    }
+
+    [Fact]
+    public void IsHypertable_Should_Accept_DateOnly_TimeColumn()
+    {
+        using DateOnlyTimeColumnContext context = new();
+        IModel model = GetModel(context);
+        IEntityType entityType = model.FindEntityType(typeof(DateOnlyTimeColumnEntity))!;
+
+        Assert.Equal("EventDate", entityType.FindAnnotation(HypertableAnnotations.HypertableTimeColumn)?.Value);
+        Assert.Equal(true, entityType.FindAnnotation(HypertableAnnotations.IsHypertable)?.Value);
+    }
+
+    #endregion
+
+    #region IsHypertable_Should_Accept_Long_TimeColumn
+
+    private class LongTimeColumnEntity
+    {
+        public long EventTimestamp { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class LongTimeColumnContext : DbContext
+    {
+        public DbSet<LongTimeColumnEntity> Metrics => Set<LongTimeColumnEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test")
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<LongTimeColumnEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("metrics_long_time");
+                entity.IsHypertable(x => x.EventTimestamp);
+            });
+        }
+    }
+
+    [Fact]
+    public void IsHypertable_Should_Accept_Long_TimeColumn()
+    {
+        using LongTimeColumnContext context = new();
+        IModel model = GetModel(context);
+        IEntityType entityType = model.FindEntityType(typeof(LongTimeColumnEntity))!;
+
+        Assert.Equal("EventTimestamp", entityType.FindAnnotation(HypertableAnnotations.HypertableTimeColumn)?.Value);
+        Assert.Equal(true, entityType.FindAnnotation(HypertableAnnotations.IsHypertable)?.Value);
+    }
+
+    #endregion
+
+    #region IsHypertable_Should_Accept_Int_TimeColumn
+
+    private class IntTimeColumnEntity
+    {
+        public int EventTimestamp { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class IntTimeColumnContext : DbContext
+    {
+        public DbSet<IntTimeColumnEntity> Metrics => Set<IntTimeColumnEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test")
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<IntTimeColumnEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("metrics_int_time");
+                entity.IsHypertable(x => x.EventTimestamp);
+            });
+        }
+    }
+
+    [Fact]
+    public void IsHypertable_Should_Accept_Int_TimeColumn()
+    {
+        using IntTimeColumnContext context = new();
+        IModel model = GetModel(context);
+        IEntityType entityType = model.FindEntityType(typeof(IntTimeColumnEntity))!;
+
+        Assert.Equal("EventTimestamp", entityType.FindAnnotation(HypertableAnnotations.HypertableTimeColumn)?.Value);
+        Assert.Equal(true, entityType.FindAnnotation(HypertableAnnotations.IsHypertable)?.Value);
+    }
+
+    #endregion
+
+    #region IsHypertable_Should_Accept_Short_TimeColumn
+
+    private class ShortTimeColumnEntity
+    {
+        public short EventTimestamp { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class ShortTimeColumnContext : DbContext
+    {
+        public DbSet<ShortTimeColumnEntity> Metrics => Set<ShortTimeColumnEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test")
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<ShortTimeColumnEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("metrics_short_time");
+                entity.IsHypertable(x => x.EventTimestamp);
+            });
+        }
+    }
+
+    [Fact]
+    public void IsHypertable_Should_Accept_Short_TimeColumn()
+    {
+        using ShortTimeColumnContext context = new();
+        IModel model = GetModel(context);
+        IEntityType entityType = model.FindEntityType(typeof(ShortTimeColumnEntity))!;
+
+        Assert.Equal("EventTimestamp", entityType.FindAnnotation(HypertableAnnotations.HypertableTimeColumn)?.Value);
+        Assert.Equal(true, entityType.FindAnnotation(HypertableAnnotations.IsHypertable)?.Value);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Description

Fixed accepted types for time columns in `IsHypertable()` and `IsContinuousAggregate()`. While the hypertable config was too losely typed, continuous aggregates were too strictly typed.

## Related Issues

Issue #48 

## Type of Change

- [x] Bug fix (non-breaking change adressing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Breaking change (fix or feature causing existing functionality to change)

## Test Plan

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (Testcontainers)
- [x] Existing tests pass (`dotnet test`)

## Checklist

- [x] Code follows the project's coding styles and guidelines
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] No new compiler warnings introduced
- [x] Public API changes have XML documentation
