### PR TITLE
Fix/50 custom time column types

### DIFF
--- a/.claude/reference/architecture.md
+++ b/.claude/reference/architecture.md
@@ -76,6 +76,9 @@ This document provides detailed architectural information for the CmdScale.Entit
 - `ContinuousAggregatePolicyBuilder.cs` - Fluent API builder
 - `ContinuousAggregateBuilderPolicyExtensions.cs` - Extension methods for builder
 
+#### Cross-cutting
+- `TimeColumnStoreTypeValidationConvention.cs` - IModelFinalizedConvention validating that hypertable and continuous-aggregate time columns resolve to a PostgreSQL time-dimension store type (timestamp/timestamptz/date/integer); backed by `Internals/TimeColumnStoreTypeValidator.cs`
+
 ### Abstractions/ - Domain Objects
 
 | File | Purpose |

--- a/.claude/reference/file-organization.md
+++ b/.claude/reference/file-organization.md
@@ -115,6 +115,8 @@ Quick reference for locating key files in the CmdScale.EntityFrameworkCore.Times
 | `Internals/Features/FeatureDiffContext.cs` | Cross-cutting diff state (renames, recreated aggregates) |
 | `Generators/SqlBuilderHelper.cs` | Identifier quoting, regclass, command grouping, SELECT→PERFORM |
 | `Generators/PolicyJobSqlBuilder.cs` | Shared `alter_job` clause builder for policies |
+| `Configuration/TimeColumnStoreTypeValidationConvention.cs` | Model-finalized validation of hypertable & continuous-aggregate time-column store types |
+| `Internals/TimeColumnStoreTypeValidator.cs` | Allowed PostgreSQL store types for a TimescaleDB time dimension |
 | `DefaultValues.cs` | Centralized defaults |
 | `Abstractions/Dimension.cs` | Range/hash partitioning |
 | `Abstractions/EAggregateFunction.cs` | Aggregate function enum |

--- a/CmdScale.EntityFrameworkCore.TimescaleDB.sln
+++ b/CmdScale.EntityFrameworkCore.TimescaleDB.sln
@@ -48,6 +48,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{DD66FBE1-7
 	ProjectSection(SolutionItems) = preProject
 		docs\00-getting-started.md = docs\00-getting-started.md
 		docs\01-dotnet-tools.md = docs\01-dotnet-tools.md
+		docs\02-nodatime.md = docs\02-nodatime.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "data-annotations", "data-annotations", "{97EBA3D4-DBB9-4564-B45B-D6ECF3A077DF}"

--- a/benchmarks/Eftdb.Benchmarks/Eftdb.Benchmarks.csproj
+++ b/benchmarks/Eftdb.Benchmarks/Eftdb.Benchmarks.csproj
@@ -15,8 +15,8 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
-    <PackageReference Include="Z.EntityFramework.Extensions.EFCore" Version="10.105.4" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.12.0" />
+    <PackageReference Include="Z.EntityFramework.Extensions.EFCore" Version="10.105.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/docs/02-nodatime.md
+++ b/docs/02-nodatime.md
@@ -1,0 +1,127 @@
+# NodaTime Support
+
+This library supports [NodaTime](https://nodatime.org/) time-column types for both hypertables and continuous aggregates The fluent API methods `IsHypertable` and `IsContinuousAggregate`, as well as the `[Hypertable]` data annotation, accept any .NET time-column type. Correctness is enforced at model finalization by validating the resolved PostgreSQL store type of the time column rather than the .NET type, so a NodaTime type is valid precisely when its Npgsql mapping resolves to a supported TimescaleDB time dimension.
+
+---
+
+## Setup
+
+The core library takes no dependency on NodaTime. NodaTime support is opt-in and provided by the official Npgsql plugin.
+
+### Install the NodaTime Plugin Package
+
+Add the [Npgsql NodaTime plugin](https://www.npgsql.org/doc/types/nodatime.html?tabs=datasource) to the project alongside the TimescaleDB packages:
+
+```bash
+dotnet add package Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime
+```
+
+### Enable the Plugin
+
+Enable the NodaTime plugin when configuring the PostgreSQL provider, then chain `.UseTimescaleDb()`:
+
+```csharp
+string? connectionString = builder.Configuration.GetConnectionString("Timescale");
+
+builder.Services.AddDbContext<TimescaleContext>(options =>
+    options.UseNpgsql(connectionString, o => o.UseNodaTime()).UseTimescaleDb());
+```
+
+Once the plugin is enabled, NodaTime types such as `Instant` and `LocalDateTime` map to PostgreSQL time types and can be used as hypertable or continuous-aggregate time columns.
+
+---
+
+## Using the Fluent API
+
+A NodaTime time column requires no special configuration. Overload resolution selects the generic `IsHypertable` overload automatically, so no explicit type arguments are needed; `builder.IsHypertable(x => x.RecordedAt)` works directly when `RecordedAt` is a NodaTime `Instant`.
+
+```csharp
+using NodaTime;
+
+public class SensorMeasurement
+{
+    public Guid Id { get; set; }
+    public Instant RecordedAt { get; set; }
+    public string SensorId { get; set; } = string.Empty;
+    public double Temperature { get; set; }
+    public double Humidity { get; set; }
+}
+```
+
+```csharp
+using CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.Hypertable;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+public class SensorMeasurementConfiguration : IEntityTypeConfiguration<SensorMeasurement>
+{
+    public void Configure(EntityTypeBuilder<SensorMeasurement> builder)
+    {
+        builder.ToTable("sensor_measurements");
+        builder.HasKey(x => new { x.Id, x.RecordedAt });
+
+        builder.IsHypertable(x => x.RecordedAt)
+               .WithChunkTimeInterval("1 day")
+               .EnableCompression()
+               .WithCompressionSegmentBy(x => x.SensorId)
+               .WithCompressionOrderBy(s => [s.ByDescending(x => x.RecordedAt)]);
+    }
+}
+```
+
+The same applies to continuous aggregates: a NodaTime source time column works with `IsContinuousAggregate` without explicit type arguments.
+
+---
+
+## Using Data Annotations
+
+The `[Hypertable]` attribute names the time column and works with any time column, including NodaTime types. The example below uses a NodaTime `LocalDateTime`
+
+```csharp
+using CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.Hypertable;
+using Microsoft.EntityFrameworkCore;
+using NodaTime;
+
+[Hypertable(nameof(ObservedAt), ChunkTimeInterval = "1 day", EnableCompression = true, CompressionSegmentBy = new[] { "Station" }, CompressionOrderBy = new[] { "ObservedAt DESC" })]
+[PrimaryKey(nameof(Id), nameof(ObservedAt))]
+public class EnvironmentReading
+{
+    public Guid Id { get; set; }
+    public LocalDateTime ObservedAt { get; set; }
+    public string Station { get; set; } = string.Empty;
+    public double Pressure { get; set; }
+    public double WindSpeed { get; set; }
+}
+```
+
+---
+
+## Supported and Unsupported NodaTime Types
+
+A NodaTime type is supported when its Npgsql store mapping resolves to a valid TimescaleDB time dimension. The supported PostgreSQL time-dimension store types are `timestamp without time zone` / `timestamp`, `timestamp with time zone` / `timestamptz`, `date`, `smallint` / `int2`, `integer` / `int` / `int4`, and `bigint` / `int8`.
+
+### Supported
+
+| NodaTime Type    | PostgreSQL Store Type            |
+| ---------------- | -------------------------------- |
+| `Instant`        | `timestamp with time zone`       |
+| `LocalDateTime`  | `timestamp without time zone`    |
+| `LocalDate`      | `date`                           |
+| `ZonedDateTime`  | `timestamp with time zone`       |
+| `OffsetDateTime` | `timestamp with time zone`       |
+
+### Unsupported
+
+The following NodaTime types do not map to a valid time dimension. Using one as a time column causes model building to throw:
+
+| NodaTime Type  | PostgreSQL Store Type      |
+| -------------- | -------------------------- |
+| `LocalTime`    | `time without time zone`   |
+| `OffsetTime`   | `time with time zone`      |
+| `Duration`     | `interval`                 |
+| `Period`       | `interval`                 |
+| `Interval`     | `tstzrange`                |
+| `DateInterval` | `daterange`                |
+
+> :warning: **Note:** Validation is performed against the resolved PostgreSQL store type of the time column at model finalization, not against the .NET type. 
+A NodaTime type is valid precisely because its Npgsql mapping resolves to a supported store type. When the resolved store type is not a valid TimescaleDB time dimension, model building throws an `InvalidOperationException`.

--- a/samples/Eftdb.Samples.CodeFirst/Eftdb.Samples.CodeFirst.csproj
+++ b/samples/Eftdb.Samples.CodeFirst/Eftdb.Samples.CodeFirst.csproj
@@ -11,7 +11,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="EFCore.NamingConventions" Version="10.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/samples/Eftdb.Samples.CodeFirst/Program.cs
+++ b/samples/Eftdb.Samples.CodeFirst/Program.cs
@@ -9,7 +9,7 @@ HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
 
 string? connectionString = builder.Configuration.GetConnectionString("Timescale");
 builder.Services.AddDbContext<TimescaleContext>(options =>
-    options.UseNpgsql(connectionString).UseTimescaleDb().UseSnakeCaseNamingConvention());
+    options.UseNpgsql(connectionString, o => o.UseNodaTime()).UseTimescaleDb().UseSnakeCaseNamingConvention());
 
 IHost host = builder.Build();
 

--- a/samples/Eftdb.Samples.Shared/Configurations/SensorMeasurementConfiguration.cs
+++ b/samples/Eftdb.Samples.Shared/Configurations/SensorMeasurementConfiguration.cs
@@ -1,0 +1,22 @@
+using CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.Hypertable;
+using CmdScale.EntityFrameworkCore.TimescaleDB.Samples.Shared.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace CmdScale.EntityFrameworkCore.TimescaleDB.Samples.Shared.Configurations
+{
+    public class SensorMeasurementConfiguration : IEntityTypeConfiguration<SensorMeasurement>
+    {
+        public void Configure(EntityTypeBuilder<SensorMeasurement> builder)
+        {
+            builder.ToTable("sensor_measurements");
+            builder.HasKey(x => new { x.Id, x.RecordedAt });
+
+            builder.IsHypertable(x => x.RecordedAt)
+                   .WithChunkTimeInterval("1 day")
+                   .EnableCompression()
+                   .WithCompressionSegmentBy(x => x.SensorId)
+                   .WithCompressionOrderBy(s => [s.ByDescending(x => x.RecordedAt)]);
+        }
+    }
+}

--- a/samples/Eftdb.Samples.Shared/Eftdb.Samples.Shared.csproj
+++ b/samples/Eftdb.Samples.Shared/Eftdb.Samples.Shared.csproj
@@ -4,6 +4,10 @@
     <ProjectReference Include="..\..\src\Eftdb\Eftdb.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="10.0.1" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/Eftdb.Samples.Shared/Eftdb.Samples.Shared.csproj
+++ b/samples/Eftdb.Samples.Shared/Eftdb.Samples.Shared.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="10.0.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="10.0.2" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/samples/Eftdb.Samples.Shared/Models/EnvironmentReading.cs
+++ b/samples/Eftdb.Samples.Shared/Models/EnvironmentReading.cs
@@ -1,0 +1,20 @@
+using CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.Hypertable;
+using Microsoft.EntityFrameworkCore;
+using NodaTime;
+
+namespace CmdScale.EntityFrameworkCore.TimescaleDB.Samples.Shared.Models
+{
+    /// <summary>
+    /// Annotation-configured hypertable whose time column is a NodaTime <see cref="LocalDateTime"/>.
+    /// </summary>
+    [Hypertable(nameof(ObservedAt), ChunkTimeInterval = "1 day", EnableCompression = true, CompressionSegmentBy = new[] { "Station" }, CompressionOrderBy = new[] { "ObservedAt DESC" })]
+    [PrimaryKey(nameof(Id), nameof(ObservedAt))]
+    public class EnvironmentReading
+    {
+        public Guid Id { get; set; }
+        public LocalDateTime ObservedAt { get; set; }
+        public string Station { get; set; } = string.Empty;
+        public double Pressure { get; set; }
+        public double WindSpeed { get; set; }
+    }
+}

--- a/samples/Eftdb.Samples.Shared/Models/SensorMeasurement.cs
+++ b/samples/Eftdb.Samples.Shared/Models/SensorMeasurement.cs
@@ -1,0 +1,16 @@
+using NodaTime;
+
+namespace CmdScale.EntityFrameworkCore.TimescaleDB.Samples.Shared.Models
+{
+    /// <summary>
+    /// IoT sensor measurement whose time column is a NodaTime <see cref="Instant"/>.
+    /// </summary>
+    public class SensorMeasurement
+    {
+        public Guid Id { get; set; }
+        public Instant RecordedAt { get; set; }
+        public string SensorId { get; set; } = string.Empty;
+        public double Temperature { get; set; }
+        public double Humidity { get; set; }
+    }
+}

--- a/samples/Eftdb.Samples.Shared/TimescaleContext.cs
+++ b/samples/Eftdb.Samples.Shared/TimescaleContext.cs
@@ -8,6 +8,8 @@ namespace CmdScale.EntityFrameworkCore.TimescaleDB.Samples.Shared
     {
         public DbSet<DeviceReading> DeviceReadings { get; set; }
         public DbSet<WeatherData> WeatherData { get; set; }
+        public DbSet<SensorMeasurement> SensorMeasurements { get; set; }
+        public DbSet<EnvironmentReading> EnvironmentReadings { get; set; }
         public DbSet<OrderStatusEvent> OrderStatusEvents { get; set; }
         public DbSet<Trade> Trades { get; set; }
         public DbSet<TradeWithId> TradesWithId { get; set; }

--- a/src/Eftdb.Design/Eftdb.Design.csproj
+++ b/src/Eftdb.Design/Eftdb.Design.csproj
@@ -24,7 +24,7 @@
 		<PackageTags>timescaledb;timescale;efcore;ef-core;entityframeworkcore;postgresql;postgres;time-series;timeseries;data;database;efcore-provider;provider;design;migrations;scaffolding;codegen;cli;tools</PackageTags>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Include="..\..\assets\cmd-nuget-logo.jpg">

--- a/src/Eftdb/Configuration/ContinuousAggregate/ContinuousAggregateTypeBuilder.cs
+++ b/src/Eftdb/Configuration/ContinuousAggregate/ContinuousAggregateTypeBuilder.cs
@@ -30,7 +30,7 @@ namespace CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.ContinuousAggre
             string? chunkInterval = null)
             where TEntity : class
             where TSourceEntity : class
-            => IsContinuousAggregateCore<TEntity, TSourceEntity>(entityTypeBuilder, materializedViewName, timeBucketWidth, Box(propertyExpression), timeBucketGroupBy, chunkInterval);
+            => IsContinuousAggregateCore(entityTypeBuilder, materializedViewName, timeBucketWidth, propertyExpression, timeBucketGroupBy, chunkInterval);
 
         /// <inheritdoc cref="IsContinuousAggregate{TEntity, TSourceEntity}(EntityTypeBuilder{TEntity}, string, string, Expression{Func{TSourceEntity, DateTime}}, bool, string)"/>
         public static ContinuousAggregateBuilder<TEntity, TSourceEntity> IsContinuousAggregate<TEntity, TSourceEntity>(
@@ -42,7 +42,7 @@ namespace CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.ContinuousAggre
             string? chunkInterval = null)
             where TEntity : class
             where TSourceEntity : class
-            => IsContinuousAggregateCore<TEntity, TSourceEntity>(entityTypeBuilder, materializedViewName, timeBucketWidth, Box(propertyExpression), timeBucketGroupBy, chunkInterval);
+            => IsContinuousAggregateCore(entityTypeBuilder, materializedViewName, timeBucketWidth, propertyExpression, timeBucketGroupBy, chunkInterval);
 
         /// <inheritdoc cref="IsContinuousAggregate{TEntity, TSourceEntity}(EntityTypeBuilder{TEntity}, string, string, Expression{Func{TSourceEntity, DateTime}}, bool, string)"/>
         public static ContinuousAggregateBuilder<TEntity, TSourceEntity> IsContinuousAggregate<TEntity, TSourceEntity>(
@@ -54,7 +54,7 @@ namespace CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.ContinuousAggre
             string? chunkInterval = null)
             where TEntity : class
             where TSourceEntity : class
-            => IsContinuousAggregateCore<TEntity, TSourceEntity>(entityTypeBuilder, materializedViewName, timeBucketWidth, Box(propertyExpression), timeBucketGroupBy, chunkInterval);
+            => IsContinuousAggregateCore(entityTypeBuilder, materializedViewName, timeBucketWidth, propertyExpression, timeBucketGroupBy, chunkInterval);
 
         /// <inheritdoc cref="IsContinuousAggregate{TEntity, TSourceEntity}(EntityTypeBuilder{TEntity}, string, string, Expression{Func{TSourceEntity, DateTime}}, bool, string)"/>
         public static ContinuousAggregateBuilder<TEntity, TSourceEntity> IsContinuousAggregate<TEntity, TSourceEntity>(
@@ -66,7 +66,7 @@ namespace CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.ContinuousAggre
             string? chunkInterval = null)
             where TEntity : class
             where TSourceEntity : class
-            => IsContinuousAggregateCore<TEntity, TSourceEntity>(entityTypeBuilder, materializedViewName, timeBucketWidth, Box(propertyExpression), timeBucketGroupBy, chunkInterval);
+            => IsContinuousAggregateCore(entityTypeBuilder, materializedViewName, timeBucketWidth, propertyExpression, timeBucketGroupBy, chunkInterval);
 
         /// <inheritdoc cref="IsContinuousAggregate{TEntity, TSourceEntity}(EntityTypeBuilder{TEntity}, string, string, Expression{Func{TSourceEntity, DateTime}}, bool, string)"/>
         public static ContinuousAggregateBuilder<TEntity, TSourceEntity> IsContinuousAggregate<TEntity, TSourceEntity>(
@@ -78,7 +78,7 @@ namespace CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.ContinuousAggre
             string? chunkInterval = null)
             where TEntity : class
             where TSourceEntity : class
-            => IsContinuousAggregateCore<TEntity, TSourceEntity>(entityTypeBuilder, materializedViewName, timeBucketWidth, Box(propertyExpression), timeBucketGroupBy, chunkInterval);
+            => IsContinuousAggregateCore(entityTypeBuilder, materializedViewName, timeBucketWidth, propertyExpression, timeBucketGroupBy, chunkInterval);
 
         /// <inheritdoc cref="IsContinuousAggregate{TEntity, TSourceEntity}(EntityTypeBuilder{TEntity}, string, string, Expression{Func{TSourceEntity, DateTime}}, bool, string)"/>
         public static ContinuousAggregateBuilder<TEntity, TSourceEntity> IsContinuousAggregate<TEntity, TSourceEntity>(
@@ -90,13 +90,37 @@ namespace CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.ContinuousAggre
             string? chunkInterval = null)
             where TEntity : class
             where TSourceEntity : class
-            => IsContinuousAggregateCore<TEntity, TSourceEntity>(entityTypeBuilder, materializedViewName, timeBucketWidth, Box(propertyExpression), timeBucketGroupBy, chunkInterval);
+            => IsContinuousAggregateCore(entityTypeBuilder, materializedViewName, timeBucketWidth, propertyExpression, timeBucketGroupBy, chunkInterval);
 
-        private static ContinuousAggregateBuilder<TEntity, TSourceEntity> IsContinuousAggregateCore<TEntity, TSourceEntity>(
+        /// <summary>
+        /// Configures the entity as a TimescaleDB continuous aggregate using a time column of any mapped type.
+        /// </summary>
+        /// <typeparam name="TEntity">The continuous aggregate entity type.</typeparam>
+        /// <typeparam name="TSourceEntity">The source hypertable entity type.</typeparam>
+        /// <typeparam name="TProperty">The .NET type of the source time column.</typeparam>
+        /// <param name="entityTypeBuilder">The entity type builder.</param>
+        /// <param name="materializedViewName">The name of the materialized view.</param>
+        /// <param name="timeBucketWidth">The time bucket width interval (e.g., "1 hour", "1 day").</param>
+        /// <param name="propertyExpression">Expression selecting the time column from the source entity.</param>
+        /// <param name="timeBucketGroupBy">Whether to include time_bucket in GROUP BY clause.</param>
+        /// <param name="chunkInterval">Optional chunk interval for the continuous aggregate.</param>
+        /// <returns>A builder for further continuous aggregate configuration.</returns>
+        public static ContinuousAggregateBuilder<TEntity, TSourceEntity> IsContinuousAggregate<TEntity, TSourceEntity, TProperty>(
+            this EntityTypeBuilder<TEntity> entityTypeBuilder,
+            string materializedViewName,
+            string timeBucketWidth,
+            Expression<Func<TSourceEntity, TProperty>> propertyExpression,
+            bool timeBucketGroupBy = true,
+            string? chunkInterval = null)
+            where TEntity : class
+            where TSourceEntity : class
+            => IsContinuousAggregateCore(entityTypeBuilder, materializedViewName, timeBucketWidth, propertyExpression, timeBucketGroupBy, chunkInterval);
+
+        private static ContinuousAggregateBuilder<TEntity, TSourceEntity> IsContinuousAggregateCore<TEntity, TSourceEntity, TProperty>(
             EntityTypeBuilder<TEntity> entityTypeBuilder,
             string materializedViewName,
             string timeBucketWidth,
-            Expression<Func<TSourceEntity, object>> propertyExpression,
+            Expression<Func<TSourceEntity, TProperty>> propertyExpression,
             bool timeBucketGroupBy,
             string? chunkInterval)
             where TEntity : class
@@ -123,14 +147,5 @@ namespace CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.ContinuousAggre
 
             return new ContinuousAggregateBuilder<TEntity, TSourceEntity>(entityTypeBuilder);
         }
-
-        // Lifts a typed time-column expression to Expression<Func<TSourceEntity, object>> by inserting
-        // a Convert node, so the shared core method can extract the property name uniformly.
-        private static Expression<Func<TSourceEntity, object>> Box<TSourceEntity, TProperty>(
-            Expression<Func<TSourceEntity, TProperty>> expression)
-            where TProperty : struct
-            => Expression.Lambda<Func<TSourceEntity, object>>(
-                Expression.Convert(expression.Body, typeof(object)),
-                expression.Parameters);
     }
 }

--- a/src/Eftdb/Configuration/Hypertable/HypertableTypeBuilder.cs
+++ b/src/Eftdb/Configuration/Hypertable/HypertableTypeBuilder.cs
@@ -24,41 +24,53 @@ namespace CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.Hypertable
         public static EntityTypeBuilder<TEntity> IsHypertable<TEntity>(
             this EntityTypeBuilder<TEntity> entityTypeBuilder,
             Expression<Func<TEntity, DateTime>> timePropertyExpression) where TEntity : class
-            => IsHypertableCore(entityTypeBuilder, Box(timePropertyExpression));
+            => IsHypertableCore(entityTypeBuilder, timePropertyExpression);
 
         /// <inheritdoc cref="IsHypertable{TEntity}(EntityTypeBuilder{TEntity}, Expression{Func{TEntity, DateTime}})"/>
         public static EntityTypeBuilder<TEntity> IsHypertable<TEntity>(
             this EntityTypeBuilder<TEntity> entityTypeBuilder,
             Expression<Func<TEntity, DateTimeOffset>> timePropertyExpression) where TEntity : class
-            => IsHypertableCore(entityTypeBuilder, Box(timePropertyExpression));
+            => IsHypertableCore(entityTypeBuilder, timePropertyExpression);
 
         /// <inheritdoc cref="IsHypertable{TEntity}(EntityTypeBuilder{TEntity}, Expression{Func{TEntity, DateTime}})"/>
         public static EntityTypeBuilder<TEntity> IsHypertable<TEntity>(
             this EntityTypeBuilder<TEntity> entityTypeBuilder,
             Expression<Func<TEntity, DateOnly>> timePropertyExpression) where TEntity : class
-            => IsHypertableCore(entityTypeBuilder, Box(timePropertyExpression));
+            => IsHypertableCore(entityTypeBuilder, timePropertyExpression);
 
         /// <inheritdoc cref="IsHypertable{TEntity}(EntityTypeBuilder{TEntity}, Expression{Func{TEntity, DateTime}})"/>
         public static EntityTypeBuilder<TEntity> IsHypertable<TEntity>(
             this EntityTypeBuilder<TEntity> entityTypeBuilder,
             Expression<Func<TEntity, long>> timePropertyExpression) where TEntity : class
-            => IsHypertableCore(entityTypeBuilder, Box(timePropertyExpression));
+            => IsHypertableCore(entityTypeBuilder, timePropertyExpression);
 
         /// <inheritdoc cref="IsHypertable{TEntity}(EntityTypeBuilder{TEntity}, Expression{Func{TEntity, DateTime}})"/>
         public static EntityTypeBuilder<TEntity> IsHypertable<TEntity>(
             this EntityTypeBuilder<TEntity> entityTypeBuilder,
             Expression<Func<TEntity, int>> timePropertyExpression) where TEntity : class
-            => IsHypertableCore(entityTypeBuilder, Box(timePropertyExpression));
+            => IsHypertableCore(entityTypeBuilder, timePropertyExpression);
 
         /// <inheritdoc cref="IsHypertable{TEntity}(EntityTypeBuilder{TEntity}, Expression{Func{TEntity, DateTime}})"/>
         public static EntityTypeBuilder<TEntity> IsHypertable<TEntity>(
             this EntityTypeBuilder<TEntity> entityTypeBuilder,
             Expression<Func<TEntity, short>> timePropertyExpression) where TEntity : class
-            => IsHypertableCore(entityTypeBuilder, Box(timePropertyExpression));
+            => IsHypertableCore(entityTypeBuilder, timePropertyExpression);
 
-        private static EntityTypeBuilder<TEntity> IsHypertableCore<TEntity>(
+        /// <summary>
+        /// Configures the entity as a TimescaleDB hypertable using a time column of any mapped type.
+        /// </summary>
+        /// <typeparam name="TEntity">The entity type being configured.</typeparam>
+        /// <typeparam name="TProperty">The .NET type of the time column.</typeparam>
+        /// <param name="entityTypeBuilder">The builder for the entity type.</param>
+        /// <param name="timePropertyExpression">A lambda expression representing the time column (e.g., <c>x =&gt; x.Timestamp</c>).</param>
+        public static EntityTypeBuilder<TEntity> IsHypertable<TEntity, TProperty>(
+            this EntityTypeBuilder<TEntity> entityTypeBuilder,
+            Expression<Func<TEntity, TProperty>> timePropertyExpression) where TEntity : class
+            => IsHypertableCore(entityTypeBuilder, timePropertyExpression);
+
+        private static EntityTypeBuilder<TEntity> IsHypertableCore<TEntity, TProperty>(
             EntityTypeBuilder<TEntity> entityTypeBuilder,
-            Expression<Func<TEntity, object>> timePropertyExpression) where TEntity : class
+            Expression<Func<TEntity, TProperty>> timePropertyExpression) where TEntity : class
         {
             string propertyName = GetPropertyName(timePropertyExpression);
 
@@ -67,15 +79,6 @@ namespace CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.Hypertable
 
             return entityTypeBuilder;
         }
-
-        // Lifts a typed time-column expression to Expression<Func<TEntity, object>> by inserting a Convert
-        // node, so the shared core method can extract the property name uniformly via GetPropertyName.
-        private static Expression<Func<TEntity, object>> Box<TEntity, TProperty>(
-            Expression<Func<TEntity, TProperty>> expression)
-            where TProperty : struct
-            => Expression.Lambda<Func<TEntity, object>>(
-                Expression.Convert(expression.Body, typeof(object)),
-                expression.Parameters);
 
         /// <summary>
         /// Adds an additional partitioning dimension to the hypertable.
@@ -251,17 +254,17 @@ namespace CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.Hypertable
         /// Extracts the property name from a member access lambda expression.
         /// </summary>
         /// <typeparam name="TEntity">The entity type.</typeparam>
+        /// <typeparam name="TProperty">The type of the selected property.</typeparam>
         /// <param name="propertyExpression">The expression to parse.</param>
         /// <returns>The name of the property.</returns>
         /// <exception cref="ArgumentException">Thrown if the expression is not a valid property expression.</exception>
-        private static string GetPropertyName<TEntity>(Expression<Func<TEntity, object>> propertyExpression)
+        private static string GetPropertyName<TEntity, TProperty>(Expression<Func<TEntity, TProperty>> propertyExpression)
         {
             if (propertyExpression.Body is MemberExpression memberExpression)
             {
                 return memberExpression.Member.Name;
             }
 
-            // This handles cases where the property is a value type (e.g., DateTime)
             if (propertyExpression.Body is UnaryExpression unaryExpression && unaryExpression.Operand is MemberExpression unaryMemberExpression)
             {
                 return unaryMemberExpression.Member.Name;

--- a/src/Eftdb/Configuration/TimeColumnStoreTypeValidationConvention.cs
+++ b/src/Eftdb/Configuration/TimeColumnStoreTypeValidationConvention.cs
@@ -1,0 +1,161 @@
+using CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.ContinuousAggregate;
+using CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.Hypertable;
+using CmdScale.EntityFrameworkCore.TimescaleDB.Internals;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+
+namespace CmdScale.EntityFrameworkCore.TimescaleDB.Configuration
+{
+    /// <summary>
+    /// This is the authoritative guardrail for time-column types: the fluent API accepts any .NET type 
+    /// so that custom mappings (such as the Npgsql NodaTime plugin) work, and correctness is enforced 
+    /// here against the resolved store type.
+    /// </summary>
+    public class TimeColumnStoreTypeValidationConvention : IModelFinalizedConvention
+    {
+        /// <summary>
+        /// Called once the model has been finalized and relational type mappings are resolved.
+        /// </summary>
+        /// <param name="model">The finalized model.</param>
+        /// <returns>The unchanged model.</returns>
+        public IModel ProcessModelFinalized(IModel model)
+        {
+            foreach (IEntityType entityType in model.GetEntityTypes())
+            {
+                ValidateHypertableTimeColumn(entityType);
+                ValidateContinuousAggregateTimeColumn(model, entityType);
+            }
+
+            return model;
+        }
+
+        private static void ValidateHypertableTimeColumn(IEntityType entityType)
+        {
+            bool isHypertable = entityType.FindAnnotation(HypertableAnnotations.IsHypertable)?.Value as bool? ?? false;
+            if (!isHypertable)
+            {
+                return;
+            }
+
+            string? timeColumnName = entityType.FindAnnotation(HypertableAnnotations.HypertableTimeColumn)?.Value as string;
+            if (string.IsNullOrWhiteSpace(timeColumnName))
+            {
+                return;
+            }
+
+            IProperty? property = ResolveProperty(entityType, timeColumnName);
+            if (property == null)
+            {
+                // Unresolvable column names are left to the model extractor, which skips them; this keeps
+                // behaviour consistent and avoids false positives on design-time/scaffolded models.
+                return;
+            }
+
+            EnsureValidTimeColumn(property, $"hypertable '{DisplayName(entityType)}'", timeColumnName);
+        }
+
+        private static void ValidateContinuousAggregateTimeColumn(IModel model, IEntityType entityType)
+        {
+            string? materializedViewName = entityType.FindAnnotation(ContinuousAggregateAnnotations.MaterializedViewName)?.Value as string;
+            if (string.IsNullOrWhiteSpace(materializedViewName))
+            {
+                return;
+            }
+
+            // The raw view-definition path does not use the structured time-bucket source column.
+            string? viewDefinition = entityType.FindAnnotation(ContinuousAggregateAnnotations.ViewDefinition)?.Value as string;
+            if (!string.IsNullOrWhiteSpace(viewDefinition))
+            {
+                return;
+            }
+
+            string? sourceColumnName = entityType.FindAnnotation(ContinuousAggregateAnnotations.TimeBucketSourceColumn)?.Value as string;
+            if (string.IsNullOrWhiteSpace(sourceColumnName))
+            {
+                return;
+            }
+
+            string? parentName = entityType.FindAnnotation(ContinuousAggregateAnnotations.ParentName)?.Value as string;
+            if (string.IsNullOrWhiteSpace(parentName))
+            {
+                return;
+            }
+
+            IEntityType? parentEntityType = model.GetEntityTypes()
+                .FirstOrDefault(e =>
+                    e.ClrType?.Name == parentName
+                    || e.ShortName() == parentName
+                    || e.GetTableName() == parentName);
+            if (parentEntityType == null)
+            {
+                return;
+            }
+
+            IProperty? property = ResolveProperty(parentEntityType, sourceColumnName);
+            if (property == null)
+            {
+                return;
+            }
+
+            EnsureValidTimeColumn(property, $"continuous aggregate '{DisplayName(entityType)}'", sourceColumnName);
+        }
+
+        private static void EnsureValidTimeColumn(IProperty property, string owner, string columnModelName)
+        {
+            string? storeType = property.GetColumnType();
+            if (string.IsNullOrWhiteSpace(storeType))
+            {
+                storeType = property.FindRelationalTypeMapping()?.StoreType;
+            }
+
+            // If the store type cannot be determined, do not block model building.
+            if (string.IsNullOrWhiteSpace(storeType))
+            {
+                return;
+            }
+
+            if (!TimeColumnStoreTypeValidator.IsValid(storeType))
+            {
+                throw new InvalidOperationException($"The time column '{columnModelName}' on {owner} maps to PostgreSQL type '{storeType}', which is not a valid TimescaleDB time dimension.");
+            }
+        }
+
+        private static IProperty? ResolveProperty(IEntityType entityType, string nameOrColumn)
+        {
+            IProperty? direct = entityType.FindProperty(nameOrColumn);
+            if (direct != null)
+            {
+                return direct;
+            }
+
+            StoreObjectIdentifier? storeIdentifier = GetStoreObjectIdentifier(entityType);
+            if (storeIdentifier == null)
+            {
+                return null;
+            }
+
+            return entityType.GetProperties()
+                .FirstOrDefault(p => string.Equals(p.GetColumnName(storeIdentifier.Value), nameOrColumn, StringComparison.Ordinal));
+        }
+
+        private static StoreObjectIdentifier? GetStoreObjectIdentifier(IEntityType entityType)
+        {
+            string? tableName = entityType.GetTableName();
+            if (!string.IsNullOrWhiteSpace(tableName))
+            {
+                return StoreObjectIdentifier.Table(tableName, entityType.GetSchema());
+            }
+
+            string? viewName = entityType.GetViewName();
+            if (!string.IsNullOrWhiteSpace(viewName))
+            {
+                return StoreObjectIdentifier.View(viewName, entityType.GetViewSchema() ?? entityType.GetSchema());
+            }
+
+            return null;
+        }
+
+        private static string DisplayName(IEntityType entityType) => entityType.ClrType?.Name ?? entityType.Name;
+    }
+}

--- a/src/Eftdb/Configuration/TimeColumnStoreTypeValidationConvention.cs
+++ b/src/Eftdb/Configuration/TimeColumnStoreTypeValidationConvention.cs
@@ -102,12 +102,15 @@ namespace CmdScale.EntityFrameworkCore.TimescaleDB.Configuration
         }
 
         private static void EnsureValidTimeColumn(IProperty property, string owner, string columnModelName)
+            => EnsureValidTimeColumn(property.GetColumnType(), property.FindRelationalTypeMapping()?.StoreType, owner, columnModelName);
+
+        /// <summary>
+        /// Validates the resolved store type of a time column, preferring the explicit column type and
+        /// falling back to the relational type mapping's store type.
+        /// </summary>
+        internal static void EnsureValidTimeColumn(string? columnType, string? mappingStoreType, string owner, string columnModelName)
         {
-            string? storeType = property.GetColumnType();
-            if (string.IsNullOrWhiteSpace(storeType))
-            {
-                storeType = property.FindRelationalTypeMapping()?.StoreType;
-            }
+            string? storeType = string.IsNullOrWhiteSpace(columnType) ? mappingStoreType : columnType;
 
             // If the store type cannot be determined, do not block model building.
             if (string.IsNullOrWhiteSpace(storeType))

--- a/src/Eftdb/Eftdb.csproj
+++ b/src/Eftdb/Eftdb.csproj
@@ -41,6 +41,6 @@
     <InternalsVisibleTo Include="CmdScale.EntityFrameworkCore.TimescaleDB.Tests" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
   </ItemGroup>
 </Project>

--- a/src/Eftdb/Internals/TimeColumnStoreTypeValidator.cs
+++ b/src/Eftdb/Internals/TimeColumnStoreTypeValidator.cs
@@ -1,0 +1,70 @@
+using System.Text.RegularExpressions;
+
+namespace CmdScale.EntityFrameworkCore.TimescaleDB.Internals
+{
+    /// <summary>
+    /// Determines whether a resolved PostgreSQL store type is valid as a TimescaleDB time/partition
+    /// dimension.
+    /// </summary>
+    /// <remarks>
+    /// Validation is performed against the resolved store type rather than the .NET type, because the
+    /// .NET type is not authoritative: custom mappings (for example the Npgsql NodaTime plugin mapping
+    /// <c>Instant</c> to <c>timestamptz</c>, or a value-converted type) are valid precisely because of
+    /// the store-type mapping they register.
+    /// </remarks>
+    internal static partial class TimeColumnStoreTypeValidator
+    {
+        // PostgreSQL store types accepted by TimescaleDB as a time dimension
+        private static readonly HashSet<string> AllowedStoreTypes = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "timestamp without time zone",
+            "timestamp with time zone",
+            "timestamp",
+            "timestamptz",
+            "date",
+            "smallint",
+            "int2",
+            "integer",
+            "int",
+            "int4",
+            "bigint",
+            "int8",
+        };
+
+        /// <summary>
+        /// Returns <c>true</c> if <paramref name="storeType"/> is a PostgreSQL type valid as a TimescaleDB time dimension.
+        /// </summary>
+        public static bool IsValid(string? storeType)
+        {
+            string? normalized = Normalize(storeType);
+            return normalized != null && AllowedStoreTypes.Contains(normalized);
+        }
+
+        // Strips a length/precision qualifier (e.g. "timestamp(6) with time zone" -> "timestamp with
+        // time zone") and collapses whitespace so the comparison is robust to formatting.
+        private static string? Normalize(string? storeType)
+        {
+            if (string.IsNullOrWhiteSpace(storeType))
+            {
+                return null;
+            }
+
+            string value = storeType.Trim();
+
+            int open = value.IndexOf('(');
+            if (open >= 0)
+            {
+                int close = value.IndexOf(')', open);
+                if (close > open)
+                {
+                    value = value[..open] + value[(close + 1)..];
+                }
+            }
+
+            return WhitespaceRegex().Replace(value, " ").Trim();
+        }
+
+        [GeneratedRegex(@"\s+")]
+        private static partial Regex WhitespaceRegex();
+    }
+}

--- a/src/Eftdb/TimescaleDbContextOptionsBuilderExtensions.cs
+++ b/src/Eftdb/TimescaleDbContextOptionsBuilderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.ContinuousAggregate;
+﻿using CmdScale.EntityFrameworkCore.TimescaleDB.Configuration;
+using CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.ContinuousAggregate;
 using CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.ContinuousAggregatePolicy;
 using CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.Hypertable;
 using CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.ReorderPolicy;
@@ -87,6 +88,7 @@ namespace CmdScale.EntityFrameworkCore.TimescaleDB
                 conventionSet.EntityTypeAddedConventions.Add(new ContinuousAggregateConvention());
                 conventionSet.EntityTypeAddedConventions.Add(new ContinuousAggregatePolicyConvention());
                 conventionSet.EntityTypeAddedConventions.Add(new RetentionPolicyConvention());
+                conventionSet.ModelFinalizedConventions.Add(new TimeColumnStoreTypeValidationConvention());
                 return conventionSet;
             }
         }

--- a/tests/Eftdb.FunctionalTests/Eftdb.FunctionalTests.csproj
+++ b/tests/Eftdb.FunctionalTests/Eftdb.FunctionalTests.csproj
@@ -12,16 +12,16 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="coverlet.collector" Version="10.0.0">
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational.Specification.Tests" Version="10.0.7" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="10.0.1" />
-		<PackageReference Include="Npgsql.NetTopologySuite" Version="10.0.2" />
-		<PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.9" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational.Specification.Tests" Version="10.0.9" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="10.0.2" />
+		<PackageReference Include="Npgsql.NetTopologySuite" Version="10.0.3" />
+		<PackageReference Include="Testcontainers.PostgreSql" Version="4.12.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/tests/Eftdb.Tests/Conventions/TimeColumnStoreTypeValidationConventionTests.cs
+++ b/tests/Eftdb.Tests/Conventions/TimeColumnStoreTypeValidationConventionTests.cs
@@ -1,0 +1,459 @@
+using CmdScale.EntityFrameworkCore.TimescaleDB.Abstractions;
+using CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.ContinuousAggregate;
+using CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.Hypertable;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using NodaTime;
+
+namespace CmdScale.EntityFrameworkCore.TimescaleDB.Tests.Conventions;
+
+/// <summary>
+/// Tests that verify TimeColumnStoreTypeValidationConvention validates the resolved PostgreSQL store
+/// type of hypertable and continuous aggregate time columns during model finalization.
+/// </summary>
+public class TimeColumnStoreTypeValidationConventionTests
+{
+    private static IModel GetModel(DbContext context)
+    {
+        return context.GetService<IDesignTimeModel>().Model;
+    }
+
+    #region Should_Allow_Custom_TimeColumn_Mapped_To_Timestamp
+
+    // Stands in for a custom time type (e.g. NodaTime Instant) mapped to a timestamp store type via a
+    // value converter. The .NET type is unknown to the library; validity comes from the store mapping.
+    private readonly struct CustomInstant(DateTime utcDateTime)
+    {
+        public DateTime UtcDateTime { get; } = utcDateTime;
+    }
+
+    private class CustomTimeEntity
+    {
+        public CustomInstant Time { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class CustomTimeContext : DbContext
+    {
+        public DbSet<CustomTimeEntity> Metrics => Set<CustomTimeEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test")
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<CustomTimeEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("validation_custom_time");
+                entity.Property(x => x.Time)
+                      .HasConversion(v => v.UtcDateTime, v => new CustomInstant(v));
+                entity.IsHypertable(x => x.Time);
+            });
+        }
+    }
+
+    [Fact]
+    public void Should_Allow_Custom_TimeColumn_Mapped_To_Timestamp()
+    {
+        using CustomTimeContext context = new();
+
+        IModel model = GetModel(context);
+        IEntityType entityType = model.FindEntityType(typeof(CustomTimeEntity))!;
+
+        Assert.Equal(true, entityType.FindAnnotation(HypertableAnnotations.IsHypertable)?.Value);
+    }
+
+    #endregion
+
+    #region Should_Throw_When_Hypertable_TimeColumn_Maps_To_Boolean
+
+    private class BooleanTimeEntity
+    {
+        public bool Flag { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class BooleanTimeContext : DbContext
+    {
+        public DbSet<BooleanTimeEntity> Metrics => Set<BooleanTimeEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test")
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<BooleanTimeEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("validation_boolean_time");
+                entity.IsHypertable(x => x.Flag);
+            });
+        }
+    }
+
+    [Fact]
+    public void Should_Throw_When_Hypertable_TimeColumn_Maps_To_Boolean()
+    {
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+        {
+            using BooleanTimeContext context = new();
+            IModel model = GetModel(context);
+        });
+
+        Assert.Contains("not a valid TimescaleDB time dimension", exception.Message);
+        Assert.Contains("Flag", exception.Message);
+    }
+
+    #endregion
+
+    #region Should_Throw_When_Hypertable_TimeColumn_Maps_To_Guid
+
+    private class GuidTimeEntity
+    {
+        public Guid EventId { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class GuidTimeContext : DbContext
+    {
+        public DbSet<GuidTimeEntity> Metrics => Set<GuidTimeEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test")
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<GuidTimeEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("validation_guid_time");
+                entity.IsHypertable(x => x.EventId);
+            });
+        }
+    }
+
+    [Fact]
+    public void Should_Throw_When_Hypertable_TimeColumn_Maps_To_Guid()
+    {
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+        {
+            using GuidTimeContext context = new();
+            IModel model = GetModel(context);
+        });
+
+        Assert.Contains("not a valid TimescaleDB time dimension", exception.Message);
+        Assert.Contains("EventId", exception.Message);
+    }
+
+    #endregion
+
+    #region Should_Allow_ContinuousAggregate_With_Valid_Source_TimeColumn
+
+    private class ValidCaggSourceEntity
+    {
+        public DateTime Timestamp { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class ValidCaggAggregateEntity
+    {
+        public DateTime TimeBucket { get; set; }
+        public double AvgValue { get; set; }
+    }
+
+    private class ValidCaggContext : DbContext
+    {
+        public DbSet<ValidCaggSourceEntity> Metrics => Set<ValidCaggSourceEntity>();
+        public DbSet<ValidCaggAggregateEntity> HourlyMetrics => Set<ValidCaggAggregateEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test")
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<ValidCaggSourceEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("validation_cagg_source");
+                entity.IsHypertable(x => x.Timestamp);
+            });
+
+            modelBuilder.Entity<ValidCaggAggregateEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.IsContinuousAggregate<ValidCaggAggregateEntity, ValidCaggSourceEntity>(
+                    "validation_cagg_view",
+                    "1 hour",
+                    x => x.Timestamp)
+                .AddAggregateFunction(x => x.AvgValue, x => x.Value, EAggregateFunction.Avg);
+            });
+        }
+    }
+
+    [Fact]
+    public void Should_Allow_ContinuousAggregate_With_Valid_Source_TimeColumn()
+    {
+        using ValidCaggContext context = new();
+
+        IModel model = GetModel(context);
+        IEntityType entityType = model.FindEntityType(typeof(ValidCaggAggregateEntity))!;
+
+        Assert.Equal("validation_cagg_view", entityType.FindAnnotation(ContinuousAggregateAnnotations.MaterializedViewName)?.Value);
+    }
+
+    #endregion
+
+    #region Should_Throw_When_ContinuousAggregate_SourceColumn_Maps_To_Invalid_Type
+
+    private class InvalidCaggSourceEntity
+    {
+        public DateTime Timestamp { get; set; }
+        public bool Flag { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class InvalidCaggAggregateEntity
+    {
+        public bool TimeBucket { get; set; }
+        public double AvgValue { get; set; }
+    }
+
+    private class InvalidCaggContext : DbContext
+    {
+        public DbSet<InvalidCaggSourceEntity> Metrics => Set<InvalidCaggSourceEntity>();
+        public DbSet<InvalidCaggAggregateEntity> HourlyMetrics => Set<InvalidCaggAggregateEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test")
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<InvalidCaggSourceEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("validation_invalid_cagg_source");
+                entity.IsHypertable(x => x.Timestamp);
+            });
+
+            modelBuilder.Entity<InvalidCaggAggregateEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.IsContinuousAggregate<InvalidCaggAggregateEntity, InvalidCaggSourceEntity, bool>(
+                    "validation_invalid_cagg_view",
+                    "1 hour",
+                    x => x.Flag)
+                .AddAggregateFunction(x => x.AvgValue, x => x.Value, EAggregateFunction.Avg);
+            });
+        }
+    }
+
+    [Fact]
+    public void Should_Throw_When_ContinuousAggregate_SourceColumn_Maps_To_Invalid_Type()
+    {
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+        {
+            using InvalidCaggContext context = new();
+            IModel model = GetModel(context);
+        });
+
+        Assert.Contains("not a valid TimescaleDB time dimension", exception.Message);
+        Assert.Contains("continuous aggregate", exception.Message);
+    }
+
+    #endregion
+
+    #region Should_Allow_All_Relevant_NodaTime_Time_Column_Types
+
+    // NodaTime date/time types whose Npgsql store mapping is a valid TimescaleDB time dimension.
+    private class NodaInstantEntity
+    {
+        public Instant Time { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class NodaLocalDateTimeEntity
+    {
+        public LocalDateTime Time { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class NodaLocalDateEntity
+    {
+        public LocalDate Time { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class NodaZonedDateTimeEntity
+    {
+        public ZonedDateTime Time { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class NodaOffsetDateTimeEntity
+    {
+        public OffsetDateTime Time { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class NodaTimeValidContext : DbContext
+    {
+        public DbSet<NodaInstantEntity> Instants => Set<NodaInstantEntity>();
+        public DbSet<NodaLocalDateTimeEntity> LocalDateTimes => Set<NodaLocalDateTimeEntity>();
+        public DbSet<NodaLocalDateEntity> LocalDates => Set<NodaLocalDateEntity>();
+        public DbSet<NodaZonedDateTimeEntity> ZonedDateTimes => Set<NodaZonedDateTimeEntity>();
+        public DbSet<NodaOffsetDateTimeEntity> OffsetDateTimes => Set<NodaOffsetDateTimeEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test", o => o.UseNodaTime())
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<NodaInstantEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("validation_nodatime_instant");
+                entity.IsHypertable(x => x.Time);
+            });
+
+            modelBuilder.Entity<NodaLocalDateTimeEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("validation_nodatime_localdatetime");
+                entity.IsHypertable(x => x.Time);
+            });
+
+            modelBuilder.Entity<NodaLocalDateEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("validation_nodatime_localdate");
+                entity.IsHypertable(x => x.Time);
+            });
+
+            modelBuilder.Entity<NodaZonedDateTimeEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("validation_nodatime_zoneddatetime");
+                entity.IsHypertable(x => x.Time);
+            });
+
+            modelBuilder.Entity<NodaOffsetDateTimeEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("validation_nodatime_offsetdatetime");
+                entity.IsHypertable(x => x.Time);
+            });
+        }
+    }
+
+    [Theory]
+    [InlineData(typeof(NodaInstantEntity), "timestamp with time zone")]
+    [InlineData(typeof(NodaLocalDateTimeEntity), "timestamp without time zone")]
+    [InlineData(typeof(NodaLocalDateEntity), "date")]
+    [InlineData(typeof(NodaZonedDateTimeEntity), "timestamp with time zone")]
+    [InlineData(typeof(NodaOffsetDateTimeEntity), "timestamp with time zone")]
+    public void Should_Allow_All_Relevant_NodaTime_Time_Column_Types(Type entityClrType, string expectedStoreType)
+    {
+        using NodaTimeValidContext context = new();
+
+        // Building the model runs the validation convention; a non-time store type would throw here.
+        IModel model = GetModel(context);
+        IEntityType entityType = model.FindEntityType(entityClrType)!;
+
+        Assert.Equal(true, entityType.FindAnnotation(HypertableAnnotations.IsHypertable)?.Value);
+        Assert.Equal(expectedStoreType, entityType.FindProperty("Time")!.GetColumnType());
+    }
+
+    #endregion
+
+    #region Should_Throw_For_NonDimension_NodaTime_Types
+
+    // NodaTime temporal types whose Npgsql store mapping is NOT a valid TimescaleDB time dimension
+    // (per the Npgsql NodaTime mapping table). Every one must be rejected by the validation convention.
+    [Hypertable("Time")]
+    private class NodaLocalTimeEntity
+    {
+        public LocalTime Time { get; set; }
+        public double Value { get; set; }
+    }
+
+    [Hypertable("Time")]
+    private class NodaOffsetTimeEntity
+    {
+        public OffsetTime Time { get; set; }
+        public double Value { get; set; }
+    }
+
+    [Hypertable("Time")]
+    private class NodaPeriodEntity
+    {
+        public Period Time { get; set; } = null!;
+        public double Value { get; set; }
+    }
+
+    [Hypertable("Time")]
+    private class NodaDurationEntity
+    {
+        public Duration Time { get; set; }
+        public double Value { get; set; }
+    }
+
+    [Hypertable("Time")]
+    private class NodaIntervalEntity
+    {
+        public Interval Time { get; set; }
+        public double Value { get; set; }
+    }
+
+    [Hypertable("Time")]
+    private class NodaDateIntervalEntity
+    {
+        public DateInterval Time { get; set; } = null!;
+        public double Value { get; set; }
+    }
+
+    // A single generic context validates each type in isolation: the convention throws during model
+    // finalization, so each NodaTime type needs its own one-entity model.
+    private class NodaHypertableContext<TEntity> : DbContext where TEntity : class
+    {
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test", o => o.UseNodaTime())
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<TEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("validation_" + typeof(TEntity).Name.ToLowerInvariant());
+            });
+    }
+
+    [Theory]
+    [InlineData(typeof(NodaLocalTimeEntity))]    // time without time zone
+    [InlineData(typeof(NodaOffsetTimeEntity))]   // time with time zone
+    [InlineData(typeof(NodaPeriodEntity))]       // interval
+    [InlineData(typeof(NodaDurationEntity))]     // interval
+    [InlineData(typeof(NodaIntervalEntity))]     // tstzrange
+    [InlineData(typeof(NodaDateIntervalEntity))] // daterange
+    public void Should_Throw_For_NonDimension_NodaTime_Types(Type entityClrType)
+    {
+        Type contextType = typeof(NodaHypertableContext<>).MakeGenericType(entityClrType);
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+        {
+            using DbContext context = (DbContext)Activator.CreateInstance(contextType)!;
+            _ = GetModel(context);
+        });
+
+        Assert.Contains("not a valid TimescaleDB time dimension", exception.Message);
+    }
+
+    #endregion
+}

--- a/tests/Eftdb.Tests/Conventions/TimeColumnStoreTypeValidationConventionTests.cs
+++ b/tests/Eftdb.Tests/Conventions/TimeColumnStoreTypeValidationConventionTests.cs
@@ -1,4 +1,5 @@
 using CmdScale.EntityFrameworkCore.TimescaleDB.Abstractions;
+using CmdScale.EntityFrameworkCore.TimescaleDB.Configuration;
 using CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.ContinuousAggregate;
 using CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.Hypertable;
 using Microsoft.EntityFrameworkCore;
@@ -453,6 +454,297 @@ public class TimeColumnStoreTypeValidationConventionTests
         });
 
         Assert.Contains("not a valid TimescaleDB time dimension", exception.Message);
+    }
+
+    #endregion
+
+    #region Should_Not_Throw_When_Hypertable_TimeColumn_Annotation_Missing
+
+    private class MissingTimeColumnEntity
+    {
+        public DateTime Time { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class MissingTimeColumnContext : DbContext
+    {
+        public DbSet<MissingTimeColumnEntity> Metrics => Set<MissingTimeColumnEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test")
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<MissingTimeColumnEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("validation_missing_time_column");
+                entity.HasAnnotation(HypertableAnnotations.IsHypertable, true);
+            });
+        }
+    }
+
+    [Fact]
+    public void Should_Not_Throw_When_Hypertable_TimeColumn_Annotation_Missing()
+    {
+        using MissingTimeColumnContext context = new();
+
+        IModel model = GetModel(context);
+        IEntityType entityType = model.FindEntityType(typeof(MissingTimeColumnEntity))!;
+
+        Assert.Equal(true, entityType.FindAnnotation(HypertableAnnotations.IsHypertable)?.Value);
+    }
+
+    #endregion
+
+    #region Should_Not_Throw_When_Hypertable_TimeColumn_Cannot_Be_Resolved
+
+    private class UnresolvableTimeColumnEntity
+    {
+        public DateTime Time { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class UnresolvableTimeColumnContext : DbContext
+    {
+        public DbSet<UnresolvableTimeColumnEntity> Metrics => Set<UnresolvableTimeColumnEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test")
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<UnresolvableTimeColumnEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("validation_unresolvable_time_column");
+                entity.HasAnnotation(HypertableAnnotations.IsHypertable, true);
+                entity.HasAnnotation(HypertableAnnotations.HypertableTimeColumn, "does_not_exist");
+            });
+        }
+    }
+
+    [Fact]
+    public void Should_Not_Throw_When_Hypertable_TimeColumn_Cannot_Be_Resolved()
+    {
+        using UnresolvableTimeColumnContext context = new();
+
+        IModel model = GetModel(context);
+        IEntityType entityType = model.FindEntityType(typeof(UnresolvableTimeColumnEntity))!;
+
+        Assert.Equal(true, entityType.FindAnnotation(HypertableAnnotations.IsHypertable)?.Value);
+    }
+
+    #endregion
+
+    #region Should_Resolve_Hypertable_TimeColumn_By_Column_Name
+
+    private class ColumnNamedTimeEntity
+    {
+        public DateTime Moment { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class ColumnNamedTimeContext : DbContext
+    {
+        public DbSet<ColumnNamedTimeEntity> Metrics => Set<ColumnNamedTimeEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test")
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<ColumnNamedTimeEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("validation_column_named_time");
+                entity.Property(x => x.Moment).HasColumnName("event_ts");
+                entity.HasAnnotation(HypertableAnnotations.IsHypertable, true);
+                entity.HasAnnotation(HypertableAnnotations.HypertableTimeColumn, "event_ts");
+            });
+        }
+    }
+
+    [Fact]
+    public void Should_Resolve_Hypertable_TimeColumn_By_Column_Name()
+    {
+        using ColumnNamedTimeContext context = new();
+
+        IModel model = GetModel(context);
+        IEntityType entityType = model.FindEntityType(typeof(ColumnNamedTimeEntity))!;
+
+        Assert.Equal("event_ts", entityType.FindProperty("Moment")!.GetColumnName(StoreObjectIdentifier.Table("validation_column_named_time", null)));
+    }
+
+    #endregion
+
+    #region Should_Resolve_Hypertable_TimeColumn_By_Column_Name_On_View
+
+    private class ViewColumnNamedTimeEntity
+    {
+        public DateTime Moment { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class ViewColumnNamedTimeContext : DbContext
+    {
+        public DbSet<ViewColumnNamedTimeEntity> Metrics => Set<ViewColumnNamedTimeEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test")
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<ViewColumnNamedTimeEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToView("validation_view_column_named_time");
+                entity.Property(x => x.Moment).HasColumnName("event_ts");
+                entity.HasAnnotation(HypertableAnnotations.IsHypertable, true);
+                entity.HasAnnotation(HypertableAnnotations.HypertableTimeColumn, "event_ts");
+            });
+        }
+    }
+
+    [Fact]
+    public void Should_Resolve_Hypertable_TimeColumn_By_Column_Name_On_View()
+    {
+        using ViewColumnNamedTimeContext context = new();
+
+        IModel model = GetModel(context);
+        IEntityType entityType = model.FindEntityType(typeof(ViewColumnNamedTimeEntity))!;
+
+        Assert.Equal("validation_view_column_named_time", entityType.GetViewName());
+    }
+
+    #endregion
+
+    #region Should_Resolve_ContinuousAggregate_Parent_By_Table_Name
+
+    private class ParentByTableNameSourceEntity
+    {
+        public DateTime Timestamp { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class ParentByTableNameAggregateEntity
+    {
+        public DateTime TimeBucket { get; set; }
+        public double AvgValue { get; set; }
+    }
+
+    private class ParentByTableNameContext : DbContext
+    {
+        public DbSet<ParentByTableNameSourceEntity> Metrics => Set<ParentByTableNameSourceEntity>();
+        public DbSet<ParentByTableNameAggregateEntity> HourlyMetrics => Set<ParentByTableNameAggregateEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test")
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<ParentByTableNameSourceEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("validation_parent_by_table_name");
+                entity.IsHypertable(x => x.Timestamp);
+            });
+
+            modelBuilder.Entity<ParentByTableNameAggregateEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.IsContinuousAggregate<ParentByTableNameAggregateEntity, ParentByTableNameSourceEntity>(
+                    "validation_parent_by_table_name_view",
+                    "1 hour",
+                    x => x.Timestamp)
+                .AddAggregateFunction(x => x.AvgValue, x => x.Value, EAggregateFunction.Avg);
+
+                entity.HasAnnotation(ContinuousAggregateAnnotations.ParentName, "validation_parent_by_table_name");
+            });
+        }
+    }
+
+    [Fact]
+    public void Should_Resolve_ContinuousAggregate_Parent_By_Table_Name()
+    {
+        using ParentByTableNameContext context = new();
+
+        IModel model = GetModel(context);
+        IEntityType entityType = model.FindEntityType(typeof(ParentByTableNameAggregateEntity))!;
+
+        Assert.Equal("validation_parent_by_table_name", entityType.FindAnnotation(ContinuousAggregateAnnotations.ParentName)?.Value);
+    }
+
+    #endregion
+
+    #region Should_Not_Throw_When_Hypertable_Has_No_Table_Or_View
+
+    private class NoStoreObjectEntity
+    {
+        public DateTime Moment { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class NoStoreObjectContext : DbContext
+    {
+        public DbSet<NoStoreObjectEntity> Metrics => Set<NoStoreObjectEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test")
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<NoStoreObjectEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable((string?)null);
+                entity.HasAnnotation(HypertableAnnotations.IsHypertable, true);
+                entity.HasAnnotation(HypertableAnnotations.HypertableTimeColumn, "does_not_exist");
+            });
+        }
+    }
+
+    [Fact]
+    public void Should_Not_Throw_When_Hypertable_Has_No_Table_Or_View()
+    {
+        using NoStoreObjectContext context = new();
+
+        IModel model = GetModel(context);
+        IEntityType entityType = model.FindEntityType(typeof(NoStoreObjectEntity))!;
+
+        Assert.Equal(true, entityType.FindAnnotation(HypertableAnnotations.IsHypertable)?.Value);
+    }
+
+    #endregion
+
+    #region EnsureValidTimeColumn store-type resolution (direct)
+
+    [Fact]
+    public void EnsureValidTimeColumn_Falls_Back_To_Mapping_Store_Type_When_Column_Type_Blank()
+    {
+        TimeColumnStoreTypeValidationConvention.EnsureValidTimeColumn("", "timestamp with time zone", "hypertable 'Probe'", "Time");
+    }
+
+    [Fact]
+    public void EnsureValidTimeColumn_Does_Not_Throw_When_Store_Type_Undeterminable()
+    {
+        TimeColumnStoreTypeValidationConvention.EnsureValidTimeColumn(null, null, "hypertable 'Probe'", "Time");
+    }
+
+    [Fact]
+    public void EnsureValidTimeColumn_Throws_When_Resolved_Store_Type_Invalid()
+    {
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+            TimeColumnStoreTypeValidationConvention.EnsureValidTimeColumn(null, "boolean", "hypertable 'Probe'", "Time"));
+
+        Assert.Contains("not a valid TimescaleDB time dimension", exception.Message);
+        Assert.Contains("boolean", exception.Message);
     }
 
     #endregion

--- a/tests/Eftdb.Tests/Eftdb.Tests.csproj
+++ b/tests/Eftdb.Tests/Eftdb.Tests.csproj
@@ -12,16 +12,16 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="coverlet.collector" Version="10.0.0">
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="EFCore.NamingConventions" Version="10.0.1" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="10.0.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="10.0.2" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
+		<PackageReference Include="Testcontainers.PostgreSql" Version="4.12.0" />
 		<PackageReference Include="xunit.v3" Version="3.2.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/tests/Eftdb.Tests/Eftdb.Tests.csproj
+++ b/tests/Eftdb.Tests/Eftdb.Tests.csproj
@@ -18,6 +18,7 @@
 		</PackageReference>
 		<PackageReference Include="EFCore.NamingConventions" Version="10.0.1" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="10.0.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />

--- a/tests/Eftdb.Tests/Internals/TimeColumnStoreTypeValidatorTests.cs
+++ b/tests/Eftdb.Tests/Internals/TimeColumnStoreTypeValidatorTests.cs
@@ -1,0 +1,49 @@
+using CmdScale.EntityFrameworkCore.TimescaleDB.Internals;
+
+namespace CmdScale.EntityFrameworkCore.TimescaleDB.Tests.Internals;
+
+/// <summary>
+/// Tests that verify TimeColumnStoreTypeValidator accepts the PostgreSQL store types valid as a
+/// TimescaleDB time dimension and rejects everything else, including normalization of length/precision
+/// qualifiers and null or blank input.
+/// </summary>
+public class TimeColumnStoreTypeValidatorTests
+{
+    [Theory]
+    [InlineData("timestamp without time zone")]
+    [InlineData("timestamp with time zone")]
+    [InlineData("timestamp")]
+    [InlineData("timestamptz")]
+    [InlineData("date")]
+    [InlineData("smallint")]
+    [InlineData("int2")]
+    [InlineData("integer")]
+    [InlineData("int")]
+    [InlineData("int4")]
+    [InlineData("bigint")]
+    [InlineData("int8")]
+    [InlineData("TIMESTAMPTZ")]
+    [InlineData("  timestamptz  ")]
+    [InlineData("timestamp(6) with time zone")]
+    [InlineData("timestamp(3)")]
+    public void IsValid_Returns_True_For_Valid_Store_Types(string storeType)
+    {
+        Assert.True(TimeColumnStoreTypeValidator.IsValid(storeType));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("boolean")]
+    [InlineData("uuid")]
+    [InlineData("text")]
+    [InlineData("time without time zone")]
+    [InlineData("interval")]
+    [InlineData("numeric(10,2)")]
+    [InlineData("timestamp(")]
+    public void IsValid_Returns_False_For_Invalid_Store_Types(string? storeType)
+    {
+        Assert.False(TimeColumnStoreTypeValidator.IsValid(storeType));
+    }
+}

--- a/tests/Eftdb.Tests/TypeBuilders/ContinuousAggregateBuilderTests.cs
+++ b/tests/Eftdb.Tests/TypeBuilders/ContinuousAggregateBuilderTests.cs
@@ -1865,4 +1865,68 @@ public class ContinuousAggregateBuilderTests
     }
 
     #endregion
+
+    #region IsContinuousAggregate_Should_Accept_Custom_TimeColumn_Type
+
+    private readonly struct IsContinuousAggregate_Should_Accept_Custom_TimeColumn_Type_CustomInstant(DateTime utcDateTime)
+    {
+        public DateTime UtcDateTime { get; } = utcDateTime;
+    }
+
+    private class IsContinuousAggregate_Should_Accept_Custom_TimeColumn_Type_MetricEntity
+    {
+        public IsContinuousAggregate_Should_Accept_Custom_TimeColumn_Type_CustomInstant Timestamp { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class IsContinuousAggregate_Should_Accept_Custom_TimeColumn_Type_HourlyMetricAggregate
+    {
+        public DateTime TimeBucket { get; set; }
+        public double AvgValue { get; set; }
+    }
+
+    private class IsContinuousAggregate_Should_Accept_Custom_TimeColumn_Type_Context : DbContext
+    {
+        public DbSet<IsContinuousAggregate_Should_Accept_Custom_TimeColumn_Type_MetricEntity> Metrics => Set<IsContinuousAggregate_Should_Accept_Custom_TimeColumn_Type_MetricEntity>();
+        public DbSet<IsContinuousAggregate_Should_Accept_Custom_TimeColumn_Type_HourlyMetricAggregate> HourlyMetrics => Set<IsContinuousAggregate_Should_Accept_Custom_TimeColumn_Type_HourlyMetricAggregate>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test")
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<IsContinuousAggregate_Should_Accept_Custom_TimeColumn_Type_MetricEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("custom_cagg_metrics");
+                entity.Property(x => x.Timestamp)
+                      .HasConversion(v => v.UtcDateTime, v => new IsContinuousAggregate_Should_Accept_Custom_TimeColumn_Type_CustomInstant(v));
+                entity.IsHypertable(x => x.Timestamp);
+            });
+
+            modelBuilder.Entity<IsContinuousAggregate_Should_Accept_Custom_TimeColumn_Type_HourlyMetricAggregate>(entity =>
+            {
+                entity.HasNoKey();
+                entity.IsContinuousAggregate<IsContinuousAggregate_Should_Accept_Custom_TimeColumn_Type_HourlyMetricAggregate, IsContinuousAggregate_Should_Accept_Custom_TimeColumn_Type_MetricEntity, IsContinuousAggregate_Should_Accept_Custom_TimeColumn_Type_CustomInstant>(
+                    "custom_cagg_hourly_metrics",
+                    "1 hour",
+                    x => x.Timestamp)
+                .AddAggregateFunction(x => x.AvgValue, x => x.Value, EAggregateFunction.Avg);
+            });
+        }
+    }
+
+    [Fact]
+    public void IsContinuousAggregate_Should_Accept_Custom_TimeColumn_Type()
+    {
+        using IsContinuousAggregate_Should_Accept_Custom_TimeColumn_Type_Context context = new();
+        IModel model = GetModel(context);
+        IEntityType entityType = model.FindEntityType(typeof(IsContinuousAggregate_Should_Accept_Custom_TimeColumn_Type_HourlyMetricAggregate))!;
+
+        Assert.Equal("custom_cagg_hourly_metrics", entityType.FindAnnotation(ContinuousAggregateAnnotations.MaterializedViewName)?.Value);
+        Assert.Equal("Timestamp", entityType.FindAnnotation(ContinuousAggregateAnnotations.TimeBucketSourceColumn)?.Value);
+    }
+
+    #endregion
 }

--- a/tests/Eftdb.Tests/TypeBuilders/HypertableTypeBuilderTests.cs
+++ b/tests/Eftdb.Tests/TypeBuilders/HypertableTypeBuilderTests.cs
@@ -1259,4 +1259,88 @@ public class HypertableTypeBuilderTests
     }
 
     #endregion
+
+    #region WithChunkSkipping_Should_Throw_For_Non_Member_Expression
+
+    private class NonMemberExpressionEntity
+    {
+        public DateTime Timestamp { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class NonMemberExpressionContext : DbContext
+    {
+        public DbSet<NonMemberExpressionEntity> Metrics => Set<NonMemberExpressionEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test")
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<NonMemberExpressionEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("metrics_non_member_expression");
+                entity.IsHypertable(x => x.Timestamp)
+                      .WithChunkSkipping(x => x.ToString()!);
+            });
+        }
+    }
+
+    [Fact]
+    public void WithChunkSkipping_Should_Throw_For_Non_Member_Expression()
+    {
+        ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+        {
+            using NonMemberExpressionContext context = new();
+            _ = GetModel(context);
+        });
+
+        Assert.Contains("not a valid property expression", exception.Message);
+    }
+
+    #endregion
+
+    #region WithCompressionSegmentBy_Should_Throw_For_Converted_Non_Member_Expression
+
+    private class ConvertedNonMemberExpressionEntity
+    {
+        public DateTime Timestamp { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class ConvertedNonMemberExpressionContext : DbContext
+    {
+        public DbSet<ConvertedNonMemberExpressionEntity> Metrics => Set<ConvertedNonMemberExpressionEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test")
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<ConvertedNonMemberExpressionEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("metrics_converted_non_member_expression");
+                entity.IsHypertable(x => x.Timestamp)
+                      .WithCompressionSegmentBy(x => (object)(x.Value + 1));
+            });
+        }
+    }
+
+    [Fact]
+    public void WithCompressionSegmentBy_Should_Throw_For_Converted_Non_Member_Expression()
+    {
+        ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+        {
+            using ConvertedNonMemberExpressionContext context = new();
+            _ = GetModel(context);
+        });
+
+        Assert.Contains("not a valid property expression", exception.Message);
+    }
+
+    #endregion
 }

--- a/tests/Eftdb.Tests/TypeBuilders/HypertableTypeBuilderTests.cs
+++ b/tests/Eftdb.Tests/TypeBuilders/HypertableTypeBuilderTests.cs
@@ -1212,4 +1212,51 @@ public class HypertableTypeBuilderTests
     }
 
     #endregion
+
+    #region IsHypertable_Should_Accept_Custom_TimeColumn_Type
+
+    private readonly struct CustomInstant(DateTime utcDateTime)
+    {
+        public DateTime UtcDateTime { get; } = utcDateTime;
+    }
+
+    private class CustomTimeColumnEntity
+    {
+        public CustomInstant Timestamp { get; set; }
+        public double Value { get; set; }
+    }
+
+    private class CustomTimeColumnContext : DbContext
+    {
+        public DbSet<CustomTimeColumnEntity> Metrics => Set<CustomTimeColumnEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test")
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<CustomTimeColumnEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("metrics_custom_time");
+                entity.Property(x => x.Timestamp)
+                      .HasConversion(v => v.UtcDateTime, v => new CustomInstant(v));
+                entity.IsHypertable(x => x.Timestamp);
+            });
+        }
+    }
+
+    [Fact]
+    public void IsHypertable_Should_Accept_Custom_TimeColumn_Type()
+    {
+        using CustomTimeColumnContext context = new();
+        IModel model = GetModel(context);
+        IEntityType entityType = model.FindEntityType(typeof(CustomTimeColumnEntity))!;
+
+        Assert.Equal("Timestamp", entityType.FindAnnotation(HypertableAnnotations.HypertableTimeColumn)?.Value);
+        Assert.Equal(true, entityType.FindAnnotation(HypertableAnnotations.IsHypertable)?.Value);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Description

NodaTime types can be used for time columns for hypertables and continuous aggregates, now.

## Related Issues

#50 

## Type of Change

- [x] Bug fix (non-breaking change adressing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring
- [x] Documentation
- [ ] CI / build / tooling
- [ ] Breaking change (fix or feature causing existing functionality to change)

## Test Plan

- [x] Unit tests added/updated
- [x] Integration tests added/updated (Testcontainers)
- [x] Existing tests pass (`dotnet test`)

## Checklist

- [x] Code follows the project's coding styles and guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] No new compiler warnings introduced
- [x] Public API changes have XML documentation
