### PR TITLE
fix: support mismatched property/source-column types in AddAggregateFunction (#53)

### DIFF
--- a/docs/data-annotations/continuous-aggregates.md
+++ b/docs/data-annotations/continuous-aggregates.md
@@ -81,7 +81,7 @@ public class TradeAggregate
     public decimal TotalVolume { get; set; }
 
     [Aggregate(EAggregateFunction.Count, "*")]
-    public int TradeCount { get; set; }
+    public long TradeCount { get; set; }
 }
 ```
 
@@ -232,7 +232,7 @@ public class TradeHourlyAggregate
     public decimal TotalVolume { get; set; }
 
     [Aggregate(EAggregateFunction.Count, "*")]
-    public int TradeCount { get; set; }
+    public long TradeCount { get; set; }
 
     [Aggregate(EAggregateFunction.First, nameof(Trade.Price))]
     public decimal OpeningPrice { get; set; }
@@ -453,7 +453,7 @@ public class TradeHourlyAggregate
     public decimal TotalVolume { get; set; }
 
     [Aggregate(EAggregateFunction.Count, "*")]
-    public int TradeCount { get; set; }
+    public long TradeCount { get; set; }
 }
 ```
 
@@ -509,7 +509,7 @@ public class DailySummary
     public decimal TotalRevenue { get; set; }
 
     [Aggregate(EAggregateFunction.Count, nameof(OrderEvent.OrderId))]
-    public int OrderCount { get; set; }
+    public long OrderCount { get; set; }
 }
 ```
 
@@ -562,6 +562,6 @@ public class WeatherDaily
     public double AvgHumidity { get; set; }
 
     [Aggregate(EAggregateFunction.Count, "*")]
-    public int ReadingCount { get; set; }
+    public long ReadingCount { get; set; }
 }
 ```

--- a/docs/fluent-api/continuous-aggregates.md
+++ b/docs/fluent-api/continuous-aggregates.md
@@ -251,7 +251,7 @@ public class TradeAggregate
     public decimal MaxPrice { get; set; }
     public decimal MinPrice { get; set; }
     public decimal TotalVolume { get; set; }
-    public int TradeCount { get; set; }
+    public long TradeCount { get; set; }
 }
 ```
 

--- a/samples/Eftdb.Samples.Shared/Configurations/TradeAggregateConfiguration.cs
+++ b/samples/Eftdb.Samples.Shared/Configurations/TradeAggregateConfiguration.cs
@@ -16,6 +16,8 @@ namespace CmdScale.EntityFrameworkCore.TimescaleDB.Samples.Shared.Configurations
                 .AddAggregateFunction(x => x.AveragePrice, x => x.Price, EAggregateFunction.Avg)
                 .AddAggregateFunction(x => x.MinPrice, x => x.Price, EAggregateFunction.Max)
                 .AddAggregateFunction(x => x.MaxPrice, x => x.Price, EAggregateFunction.Min)
+                .AddAggregateFunction(x => x.TotalVolume, x => x.Size, EAggregateFunction.Sum)
+                .AddAggregateFunction(x => x.TradeCount, x => x.Timestamp, EAggregateFunction.Count)
                 .AddGroupByColumn(x => x.Exchange)
                 .AddGroupByColumn("1, 2")
                 .Where("\"ticker\" = 'MCRS'")

--- a/samples/Eftdb.Samples.Shared/Models/TradeAggregate.cs
+++ b/samples/Eftdb.Samples.Shared/Models/TradeAggregate.cs
@@ -5,5 +5,7 @@
         public decimal AveragePrice { get; set; }
         public decimal MaxPrice { get; set; }
         public decimal MinPrice { get; set; }
+        public decimal TotalVolume { get; set; }
+        public long TradeCount { get; set; }
     }
 }

--- a/samples/Eftdb.Samples.Shared/Models/WeatherAggregate.cs
+++ b/samples/Eftdb.Samples.Shared/Models/WeatherAggregate.cs
@@ -45,7 +45,7 @@ namespace CmdScale.EntityFrameworkCore.TimescaleDB.Samples.Shared.Models
 
         // Count aggregate function (using "*" for count all records)
         [Aggregate(EAggregateFunction.Count, "*")]
-        public int RecordCount { get; set; }
+        public long RecordCount { get; set; }
 
         // First aggregate function (gets first temperature value in time bucket)
         [Aggregate(EAggregateFunction.First, nameof(WeatherData.Temperature))]

--- a/src/Eftdb/Configuration/ContinuousAggregate/ContinuousAggregateBuilder.cs
+++ b/src/Eftdb/Configuration/ContinuousAggregate/ContinuousAggregateBuilder.cs
@@ -58,14 +58,15 @@ namespace CmdScale.EntityFrameworkCore.TimescaleDB.Configuration.ContinuousAggre
         /// <summary>
         /// Adds an aggregate function mapping between a property on the continuous aggregate and a source column.
         /// </summary>
-        /// <typeparam name="TProperty">The property type.</typeparam>
+        /// <typeparam name="TProperty">The type of the property on the continuous aggregate.</typeparam>
+        /// <typeparam name="TSourceProperty">The type of the source column on the hypertable.</typeparam>
         /// <param name="propertyExpression">Expression selecting the property on the continuous aggregate.</param>
         /// <param name="sourceColumn">Expression selecting the source column from the hypertable.</param>
         /// <param name="function">The aggregate function to apply.</param>
         /// <returns>The builder for method chaining.</returns>
-        public ContinuousAggregateBuilder<TEntity, TSourceEntity> AddAggregateFunction<TProperty>(
+        public ContinuousAggregateBuilder<TEntity, TSourceEntity> AddAggregateFunction<TProperty, TSourceProperty>(
             Expression<Func<TEntity, TProperty>> propertyExpression,
-            Expression<Func<TSourceEntity, TProperty>> sourceColumn,
+            Expression<Func<TSourceEntity, TSourceProperty>> sourceColumn,
             EAggregateFunction function)
         {
             string propertyName = GetPropertyName(propertyExpression);

--- a/tests/Eftdb.Tests/TypeBuilders/ContinuousAggregateBuilderTests.cs
+++ b/tests/Eftdb.Tests/TypeBuilders/ContinuousAggregateBuilderTests.cs
@@ -788,6 +788,69 @@ public class ContinuousAggregateBuilderTests
 
     #endregion
 
+    #region AddAggregateFunction_Should_Support_Mismatched_Property_And_SourceColumn_Types
+
+    private class CountMismatch_TradeEntity
+    {
+        public DateTime Timestamp { get; set; }
+        public string Ticker { get; set; } = string.Empty;
+        public decimal Price { get; set; }
+    }
+
+    private class CountMismatch_TradeAggregate
+    {
+        public DateTime TimeBucket { get; set; }
+        public int TradeCount { get; set; }
+        public long TickerCount { get; set; }
+    }
+
+    private class CountMismatch_Context : DbContext
+    {
+        public DbSet<CountMismatch_TradeEntity> Trades => Set<CountMismatch_TradeEntity>();
+        public DbSet<CountMismatch_TradeAggregate> HourlyTrades => Set<CountMismatch_TradeAggregate>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=localhost;Database=test;Username=test;Password=test")
+                            .UseTimescaleDb();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<CountMismatch_TradeEntity>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("Trades");
+                entity.IsHypertable(x => x.Timestamp);
+            });
+
+            modelBuilder.Entity<CountMismatch_TradeAggregate>(entity =>
+            {
+                entity.HasNoKey();
+                entity.IsContinuousAggregate<CountMismatch_TradeAggregate, CountMismatch_TradeEntity>(
+                    "hourly_trades",
+                    "1 hour",
+                    x => x.Timestamp)
+                .AddAggregateFunction(x => x.TradeCount, x => x.Timestamp, EAggregateFunction.Count)
+                .AddAggregateFunction(x => x.TickerCount, x => x.Ticker, EAggregateFunction.Count);
+            });
+        }
+    }
+
+    [Fact]
+    public void AddAggregateFunction_Should_Support_Mismatched_Property_And_SourceColumn_Types()
+    {
+        using CountMismatch_Context context = new();
+        IModel model = GetModel(context);
+        IEntityType entityType = model.FindEntityType(typeof(CountMismatch_TradeAggregate))!;
+
+        List<string>? aggregateFunctions = entityType.FindAnnotation(ContinuousAggregateAnnotations.AggregateFunctions)?.Value as List<string>;
+        Assert.NotNull(aggregateFunctions);
+        Assert.Equal(2, aggregateFunctions.Count);
+        Assert.Contains("TradeCount:Count:Timestamp", aggregateFunctions);
+        Assert.Contains("TickerCount:Count:Ticker", aggregateFunctions);
+    }
+
+    #endregion
+
     #region AddGroupByColumn_Should_Add_Single_Column_From_Expression
 
     private class AddGroupByColumn_Should_Add_Single_Column_From_Expression_MetricEntity


### PR DESCRIPTION
## Description

EAggregateFunction.Count was not usuable. This PR fixes that.

### ⚠️ Breaking Changes

`AddAggregateFunction<T>` is now `AddAggregateFunction<TProperty, TSourceProperty>` (#53) — update explicit type arguments; inferred calls compile unchanged.

## Related Issues

#53 

## Type of Change

- [x] Bug fix (non-breaking change adressing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / build / tooling
- [x] Breaking change (fix or feature causing existing functionality to change)

## Test Plan

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (Testcontainers)
- [x] Existing tests pass (`dotnet test`)

## Checklist

- [x] Code follows the project's coding styles and guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] No new compiler warnings introduced
- [x] Public API changes have XML documentation
